### PR TITLE
Parse color formats from CSS Color 4 draft

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,51 @@
+// Various color conversion functions ported from the sample code in the W3C CSS Color 4.
+
+use crate::types::Scalar;
+
+type ChannelTuple = (Scalar, Scalar, Scalar);
+
+// sRGB-related functions
+
+/// Converts a tuple of sRGB values where in-gamut values are in the range [0 - 1]
+/// to linear light (un-companded) form.
+/// (https://en.wikipedia.org/wiki/SRGB)
+///
+/// Extended transfer function:
+/// For negative values, linear portion is extended on reflection of axis,
+/// then reflected power function is used.
+pub fn lin_srgb(rgb: ChannelTuple) -> ChannelTuple {
+    let finv = |val: Scalar| {
+        let abs = val.abs();
+
+        if abs < 0.04045 {
+            val / 12.92
+        } else {
+            val.signum() * Scalar::powf((abs + 0.055) / 1.055, 2.4)
+        }
+    };
+
+    let (r, g, b) = rgb;
+    (finv(r), finv(g), finv(b))
+}
+
+/// Converts a tuple of linear-light sRGB values in the range 0.0-1.0
+/// to gamma corrected form.
+/// (https://en.wikipedia.org/wiki/SRGB)
+///
+/// Extended transfer function:
+/// For negative values, linear portion is extended on reflection of axis,
+/// then reflected power function is used.
+pub fn gam_srgb(rgb: ChannelTuple) -> ChannelTuple {
+    let f = |val: Scalar| {
+        let abs = val.abs();
+
+        if abs > 0.0031308 {
+            val.signum() * (1.055 * Scalar::powf(abs, 1.0 / 2.4) - 0.055)
+        } else {
+            12.92 * val
+        }
+    };
+
+    let (r, g, b) = rgb;
+    (f(r), f(g), f(b))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -903,9 +903,9 @@ impl From<&LCh> for Color {
 impl From<&CMYK> for Color {
     fn from(color: &CMYK) -> Self {
         #![allow(clippy::many_single_char_names)]
-        let r = 255.0 * ((1.0 - color.c) / 100.0) * ((1.0 - color.k) / 100.0);
-        let g = 255.0 * ((1.0 - color.m) / 100.0) * ((1.0 - color.k) / 100.0);
-        let b = 255.0 * ((1.0 - color.y) / 100.0) * ((1.0 - color.k) / 100.0);
+        let r = (1.0 - color.c) * (1.0 - color.k);
+        let g = (1.0 - color.m) * (1.0 - color.k);
+        let b = (1.0 - color.y) * (1.0 - color.k);
 
         Color::from(&RGBA::<f64> {
             r,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ansi;
 pub mod colorspace;
+pub mod convert;
 pub mod delta_e;
 pub mod distinct;
 mod helper;
@@ -11,6 +12,7 @@ mod types;
 use std::{fmt, str::FromStr};
 
 use colorspace::ColorSpace;
+use convert::{gam_srgb, lin_srgb};
 pub use helper::Fraction;
 use helper::{clamp, interpolate, interpolate_angle, mod_positive, MaxPrecision};
 use types::{Hue, Scalar};
@@ -818,19 +820,11 @@ impl From<&RGBA<f64>> for Color {
 
 impl From<&XYZ> for Color {
     fn from(color: &XYZ) -> Self {
-        #![allow(clippy::many_single_char_names)]
-        let f = |c| {
-            if c <= 0.003_130_8 {
-                12.92 * c
-            } else {
-                1.055 * Scalar::powf(c, 1.0 / 2.4) - 0.055
-            }
-        };
+        let r_ = 3.2406 * color.x - 1.5372 * color.y - 0.4986 * color.z;
+        let g_ = -0.9689 * color.x + 1.8758 * color.y + 0.0415 * color.z;
+        let b_ = 0.0557 * color.x - 0.2040 * color.y + 1.0570 * color.z;
 
-        let r = f(3.2406 * color.x - 1.5372 * color.y - 0.4986 * color.z);
-        let g = f(-0.9689 * color.x + 1.8758 * color.y + 0.0415 * color.z);
-        let b = f(0.0557 * color.x - 0.2040 * color.y + 1.0570 * color.z);
-
+        let (r, g, b) = gam_srgb((r_, g_, b_));
         Self::from(&RGBA::<f64> {
             r,
             g,
@@ -1119,23 +1113,12 @@ pub struct XYZ {
 
 impl From<&Color> for XYZ {
     fn from(color: &Color) -> Self {
-        #![allow(clippy::many_single_char_names)]
-        let finv = |c_: f64| {
-            if c_ <= 0.04045 {
-                c_ / 12.92
-            } else {
-                Scalar::powf((c_ + 0.055) / 1.055, 2.4)
-            }
-        };
-
         let rec = RGBA::from(color);
-        let r = finv(rec.r);
-        let g = finv(rec.g);
-        let b = finv(rec.b);
+        let (r_, g_, b_) = lin_srgb((rec.r, rec.g, rec.b));
 
-        let x = 0.4124 * r + 0.3576 * g + 0.1805 * b;
-        let y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-        let z = 0.0193 * r + 0.1192 * g + 0.9505 * b;
+        let x = 0.4124 * r_ + 0.3576 * g_ + 0.1805 * b_;
+        let y = 0.2126 * r_ + 0.7152 * g_ + 0.0722 * b_;
+        let z = 0.0193 * r_ + 0.1192 * g_ + 0.9505 * b_;
 
         XYZ {
             x,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -340,7 +340,7 @@ fn parse_named(input: &str) -> IResult<&str, Color> {
     }
 }
 
-fn parse_css_color_fn<'a>(input: &'a str) -> IResult<&'a str, Color> {
+fn parse_css_color_fn(input: &str) -> IResult<&str, Color> {
     let (input, _) = tag_no_case("color(")(input)?;
     let (input, _) = space0(input)?;
 
@@ -466,7 +466,7 @@ fn parse_css_lch65(input: &str) -> IResult<&str, Color> {
 // inconsistent and confusing values.  Where there is no ambiguity, however, we try to be lenient
 // for broader compatibility.
 
-fn parse_cie_lab65_color_space<'a>(input: &'a str) -> IResult<&'a str, Color> {
+fn parse_cie_lab65_color_space(input: &str) -> IResult<&str, Color> {
     // Custom color space "<dashed-ident>" prefix is optional.
     let (input, _) = opt(tag("--"))(input)?;
     let (input, _) = tag_no_case("lab-d65")(input)?;
@@ -485,7 +485,7 @@ fn parse_cie_lab65_color_space<'a>(input: &'a str) -> IResult<&'a str, Color> {
     Ok((input, c))
 }
 
-fn parse_cie_lch65_color_space<'a>(input: &'a str) -> IResult<&'a str, Color> {
+fn parse_cie_lch65_color_space(input: &str) -> IResult<&str, Color> {
     // Custom color space "<dashed-ident>" prefix is optional.
     let (input, _) = opt(tag("--"))(input)?;
     let (input, _) = tag_no_case("lch-d65")(input)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -341,6 +341,7 @@ fn parse_named(input: &str) -> IResult<&str, Color> {
 
 fn parse_css_color_fn<'a>(input: &'a str) -> IResult<&'a str, Color> {
     let (input, _) = tag_no_case("color(")(input)?;
+    let (input, _) = space0(input)?;
 
     let (input, color) = alt((
         parse_srgb_color_space,
@@ -1191,6 +1192,10 @@ fn parse_srgb_color_space_syntax() {
         Some(rgb(255, 8, 119)),
         parse_color("  color(srgb 1    0.031    0.467 )  ")
     );
+    assert_eq!(
+        Some(rgb(255, 0, 153)),
+        parse_color("color(   srgb   1 0 0.6)")
+    );
 
     assert_eq!(Some(rgb(255, 0, 0)), parse_color("color(srgb 1.1 0 0)"));
     assert_eq!(
@@ -1264,6 +1269,10 @@ fn parse_xyz65_color_space_syntax() {
         Some(xyz(0.3, 0.5, 0.7)),
         parse_color("color(xyz-d65  0.3   0.5    0.7)")
     );
+    assert_eq!(
+        Some(xyz(0.3, 0.5, 0.7)),
+        parse_color("color(   xyz-d65   0.3 0.5 0.7)")
+    );
 
     // color space name is case-insensitive
     assert_eq!(
@@ -1336,6 +1345,10 @@ fn parse_lab65_color_space_syntax() {
     assert_eq!(
         Some(Color::from_lab(15.0, 23.0, -43.0, 1.0)),
         parse_color("color(lab-d65     15    23      -43)")
+    );
+    assert_eq!(
+        Some(Color::from_lab(15.0, 23.0, -43.0, 1.0)),
+        parse_color("color(   lab-d65   15 23 -43)")
     );
     assert_eq!(
         Some(Color::from_lab(15.0, 23.0, -43.0, 0.6)),
@@ -1493,6 +1506,10 @@ fn parse_lch65_color_space_syntax() {
     assert_eq!(
         Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
         parse_color("color(lch-d65     15    25      90)")
+    );
+    assert_eq!(
+        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
+        parse_color("color(   lch-d65   15 25 90)")
     );
     assert_eq!(
         Some(Color::from_lch(15.0, 25.0, 90.0, 0.6)),


### PR DESCRIPTION
This adds support for parsing additional color formats from CSS Color 4.