### PR TITLE
Organize library into submodules for easier navigation

### DIFF
--- a/src/cmyk.rs
+++ b/src/cmyk.rs
@@ -1,0 +1,125 @@
+use std::fmt;
+
+use crate::{rgb::RGBA, types::Scalar, Color, Format};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CMYK {
+    pub c: Scalar,
+    pub m: Scalar,
+    pub y: Scalar,
+    pub k: Scalar,
+}
+
+impl From<&Color> for CMYK {
+    fn from(color: &Color) -> Self {
+        let rgba = RGBA::<u8>::from(color);
+        let r = (rgba.r as f64) / 255.0;
+        let g = (rgba.g as f64) / 255.0;
+        let b = (rgba.b as f64) / 255.0;
+        let biggest = if r >= g && r >= b {
+            r
+        } else if g >= r && g >= b {
+            g
+        } else {
+            b
+        };
+        let out_k = 1.0 - biggest;
+        let out_c = (1.0 - r - out_k) / biggest;
+        let out_m = (1.0 - g - out_k) / biggest;
+        let out_y = (1.0 - b - out_k) / biggest;
+
+        CMYK {
+            c: if out_c.is_nan() { 0.0 } else { out_c },
+            m: if out_m.is_nan() { 0.0 } else { out_m },
+            y: if out_y.is_nan() { 0.0 } else { out_y },
+            k: out_k,
+        }
+    }
+}
+
+// from CMYK to Color so you can do -> let new_color = Color::from(&some_cmyk);
+impl From<&CMYK> for Color {
+    fn from(color: &CMYK) -> Self {
+        #![allow(clippy::many_single_char_names)]
+        let r = (1.0 - color.c) * (1.0 - color.k);
+        let g = (1.0 - color.m) * (1.0 - color.k);
+        let b = (1.0 - color.y) * (1.0 - color.k);
+
+        Color::from(&RGBA::new(r, g, b))
+    }
+}
+
+impl fmt::Display for CMYK {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "cmyk({c}, {m}, {y}, {k})",
+            c = self.c,
+            m = self.m,
+            y = self.y,
+            k = self.k,
+        )
+    }
+}
+
+impl CMYK {
+    #[inline]
+    pub fn new(c: Scalar, m: Scalar, y: Scalar, k: Scalar) -> Self {
+        CMYK { c, m, y, k }
+    }
+
+    /// Format the color as a CMYK-representation string (`cmyk(0, 50, 100, 100)`).
+    pub fn to_color_string(&self, format: Format) -> String {
+        format!(
+            "cmyk({c},{space}{m},{space}{y},{space}{k})",
+            c = (self.c * 100.0).round(),
+            m = (self.m * 100.0).round(),
+            y = (self.y * 100.0).round(),
+            k = (self.k * 100.0).round(),
+            space = if format == Format::Spaces { " " } else { "" }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmyk_conversion() {
+        assert_eq!(Color::aqua(), Color::from_cmyk(1.0, 0.0, 0.0, 0.0));
+        assert_eq!(Color::fuchsia(), Color::from_cmyk(0.0, 1.0, 0.0, 0.0));
+        assert_eq!(Color::yellow(), Color::from_cmyk(0.0, 0.0, 1.0, 0.0));
+        assert_eq!(Color::black(), Color::from_cmyk(0.0, 0.0, 0.0, 1.0));
+
+        assert_eq!(Color::red(), Color::from_cmyk(0.0, 1.0, 1.0, 0.0));
+        assert_eq!(Color::lime(), Color::from_cmyk(1.0, 0.0, 1.0, 0.0));
+        assert_eq!(Color::blue(), Color::from_cmyk(1.0, 1.0, 0.0, 0.0));
+
+        assert_eq!(Color::green(), Color::from_cmyk(1.0, 0.0, 1.0, 0.5));
+    }
+
+    #[test]
+    fn to_cmyk_string() {
+        let white = CMYK::new(0.0, 0.0, 0.0, 0.0);
+        assert_eq!("cmyk(0, 0, 0, 0)", white.to_color_string(Format::Spaces));
+        assert_eq!("cmyk(0,0,0,0)", white.to_color_string(Format::NoSpaces));
+
+        let black = CMYK::new(0.0, 0.0, 0.0, 1.0);
+        assert_eq!("cmyk(0, 0, 0, 100)", black.to_color_string(Format::Spaces));
+        assert_eq!("cmyk(0,0,0,100)", black.to_color_string(Format::NoSpaces));
+
+        let gray = CMYK::new(0.0, 0.0, 0.0, 0.75);
+        assert_eq!("cmyk(0, 0, 0, 75)", gray.to_color_string(Format::Spaces));
+
+        let c1 = CMYK::new(0.0, 0.0, 0.95, 0.9);
+        assert_eq!("cmyk(0, 0, 95, 90)", c1.to_color_string(Format::Spaces));
+
+        let c2 = CMYK::new(0.0, 0.14, 0.43, 0.47);
+        assert_eq!("cmyk(0, 14, 43, 47)", c2.to_color_string(Format::Spaces));
+        assert_eq!("cmyk(0,14,43,47)", c2.to_color_string(Format::NoSpaces));
+
+        let c3 = CMYK::new(0.25, 0.1, 0.0, 0.5);
+        assert_eq!("cmyk(25, 10, 0, 50)", c3.to_color_string(Format::Spaces));
+    }
+}

--- a/src/cmyk.rs
+++ b/src/cmyk.rs
@@ -1,6 +1,18 @@
 use std::fmt;
 
-use crate::{rgb::RGBA, types::Scalar, Color, Format};
+use nom::{
+    bytes::complete::tag_no_case,
+    character::complete::{char, space0, space1},
+    combinator::{all_consuming, opt},
+    IResult,
+};
+
+use crate::{
+    parser::{modern_alpha, number_or_percentage},
+    rgb::RGBA,
+    types::Scalar,
+    Color, Format,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CMYK {
@@ -81,6 +93,35 @@ impl CMYK {
     }
 }
 
+pub(crate) fn parse_cmyk_color(input: &str) -> IResult<&str, Color> {
+    all_consuming(parse_css_device_cmyk)(input.trim())
+}
+
+// Parse CMYK colors as the `device-cmyk()` function defined in CSS Color 5.  The simpler `cmyk()`
+// is also accepted.  We have no color profile info here, so all CMYK colors are represented as
+// uncalibrated colors using the naive RGB conversion.
+
+fn parse_css_device_cmyk(input: &str) -> IResult<&str, Color> {
+    let (input, _) = opt(tag_no_case("device-"))(input)?;
+    let (input, _) = tag_no_case("cmyk(")(input)?;
+    let (input, _) = space0(input)?;
+    let (input, c) = number_or_percentage(input, 1.0)?;
+    let (input, _) = space1(input)?;
+    let (input, m) = number_or_percentage(input, 1.0)?;
+    let (input, _) = space1(input)?;
+    let (input, y) = number_or_percentage(input, 1.0)?;
+    let (input, _) = space1(input)?;
+    let (input, k) = number_or_percentage(input, 1.0)?;
+    // accept alpha component for compatibility, but not currently supported for CMYK
+    let (input, _alpha) = modern_alpha(input)?;
+    let (input, _) = space0(input)?;
+    let (input, _) = char(')')(input)?;
+
+    let c = Color::from_cmyk(c, m, y, k);
+
+    Ok((input, c))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +162,78 @@ mod tests {
 
         let c3 = CMYK::new(0.25, 0.1, 0.0, 0.5);
         assert_eq!("cmyk(25, 10, 0, 50)", c3.to_color_string(Format::Spaces));
+    }
+
+    fn parse_color(input: &str) -> Option<Color> {
+        parse_cmyk_color(input).ok().map(|(_, c)| c)
+    }
+
+    #[test]
+    fn parse_css_device_cmyk_syntax() {
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(80% 20% 60% 40%)")
+        );
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(0.8 0.2 0.6 0.4)")
+        );
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(80% 0.2 0.6 40%)")
+        );
+
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(80.0% 20.000% 60% 40.%)")
+        );
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(0.800 0.2 .6 0.40)")
+        );
+
+        assert_eq!(
+            Some(Color::red()),
+            parse_color("device-cmyk(0% 100% 100% 0%)")
+        );
+        assert_eq!(
+            Some(Color::green()),
+            parse_color("device-cmyk(100% 0% 100% 50%)")
+        );
+        assert_eq!(
+            Some(Color::blue()),
+            parse_color("device-cmyk(100% 100% 0% 0%)")
+        );
+        assert_eq!(Some(Color::yellow()), parse_color("device-cmyk(0 0 1 0)"));
+        assert_eq!(
+            Some(Color::from_rgb(255, 165, 0)), // orange
+            parse_color("device-cmyk(0 0.353 1 0)")
+        );
+        assert_eq!(Some(Color::purple()), parse_color("device-cmyk(0 1 0 0.5)"));
+
+        // `cmyk` is equivalent to `device-cmyk`
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("cmyk(0.8 0.2 0.6 0.4)")
+        );
+
+        // function names are case-insensitive
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("Device-CMYK(80% 20% 60% 40%)")
+        );
+
+        // alpha value is allowed for compatibility, but is ignored because it
+        // isn't currently supported by the color library
+        assert_eq!(
+            Some(Color::from_cmyk(0.8, 0.2, 0.6, 0.4)),
+            parse_color("device-cmyk(80% 20% 60% 40% / 0.5)")
+        );
+
+        assert_eq!(None, parse_color("device-cmyk(0,1,1,0)"));
+        assert_eq!(None, parse_color("device-cmyk(0 1 1)"));
+        assert_eq!(None, parse_color("device-cmyk(0 1)"));
+        assert_eq!(None, parse_color("device-cmyk(50%)"));
+        assert_eq!(None, parse_color("device-cmyk(0 1 0.5 1 0)"));
     }
 }

--- a/src/color_scale.rs
+++ b/src/color_scale.rs
@@ -1,0 +1,200 @@
+use crate::{Color, Fraction};
+
+/// The representation of a color stop for a `ColorScale`.
+/// The position defines where the color is placed from left (0.0) to right (1.0).
+#[derive(Debug, Clone)]
+struct ColorStop {
+    color: Color,
+    position: Fraction,
+}
+
+/// The representation of a color scale.
+/// The first `ColorStop` (position 0.0) defines the left end color.
+/// The last `ColorStop` (position 1.0) defines the right end color.
+#[derive(Debug, Clone)]
+pub struct ColorScale {
+    color_stops: Vec<ColorStop>,
+}
+
+impl ColorScale {
+    /// Create an empty `ColorScale`.
+    pub fn empty() -> Self {
+        Self {
+            color_stops: Vec::new(),
+        }
+    }
+
+    /// Add a `Color` at the given position.
+    pub fn add_stop(&mut self, color: Color, position: Fraction) -> &mut Self {
+        #![allow(clippy::float_cmp)]
+        let same_position = self
+            .color_stops
+            .iter_mut()
+            .find(|c| position.value() == c.position.value());
+
+        match same_position {
+            Some(color_stop) => color_stop.color = color,
+            None => {
+                let next_index = self
+                    .color_stops
+                    .iter()
+                    .position(|c| position.value() < c.position.value());
+
+                let index = next_index.unwrap_or(self.color_stops.len());
+
+                let color_stop = ColorStop { color, position };
+
+                self.color_stops.insert(index, color_stop);
+            }
+        };
+
+        self
+    }
+
+    /// Get the color at the given position using the mixing function.
+    ///
+    /// Note:
+    /// - No color is returned if position isn't between two color stops or the `ColorScale` is empty.
+    pub fn sample(
+        &self,
+        position: Fraction,
+        mix: &dyn Fn(&Color, &Color, Fraction) -> Color,
+    ) -> Option<Color> {
+        if self.color_stops.len() < 2 {
+            return None;
+        }
+
+        let left_stop = self
+            .color_stops
+            .iter()
+            .rev()
+            .find(|c| position.value() >= c.position.value());
+
+        let right_stop = self
+            .color_stops
+            .iter()
+            .find(|c| position.value() <= c.position.value());
+
+        match (left_stop, right_stop) {
+            (Some(left_stop), Some(right_stop)) => {
+                let diff_color_stops = right_stop.position.value() - left_stop.position.value();
+                let diff_position = position.value() - left_stop.position.value();
+                let local_position = Fraction::from(diff_position / diff_color_stops);
+
+                let color = mix(&left_stop.color, &right_stop.color, local_position);
+
+                Some(color)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Lab;
+
+    #[test]
+    fn color_scale_add_preserves_ordering() {
+        let mut color_scale = ColorScale::empty();
+
+        color_scale
+            .add_stop(Color::red(), Fraction::from(0.5))
+            .add_stop(Color::gray(), Fraction::from(0.0))
+            .add_stop(Color::blue(), Fraction::from(1.0));
+
+        assert_eq!(color_scale.color_stops.get(0).unwrap().color, Color::gray());
+        assert_eq!(color_scale.color_stops.get(1).unwrap().color, Color::red());
+        assert_eq!(color_scale.color_stops.get(2).unwrap().color, Color::blue());
+    }
+
+    #[test]
+    fn color_scale_empty_sample_none() {
+        let mix = Color::mix::<Lab>;
+
+        let color_scale = ColorScale::empty();
+
+        let color = color_scale.sample(Fraction::from(0.0), &mix);
+
+        assert_eq!(color, None);
+    }
+
+    #[test]
+    fn color_scale_one_color_sample_none() {
+        let mix = Color::mix::<Lab>;
+
+        let mut color_scale = ColorScale::empty();
+
+        color_scale.add_stop(Color::red(), Fraction::from(0.0));
+
+        let color = color_scale.sample(Fraction::from(0.0), &mix);
+
+        assert_eq!(color, None);
+    }
+
+    #[test]
+    fn color_scale_sample_same_position() {
+        let mix = Color::mix::<Lab>;
+
+        let mut color_scale = ColorScale::empty();
+
+        color_scale
+            .add_stop(Color::red(), Fraction::from(0.0))
+            .add_stop(Color::green(), Fraction::from(1.0))
+            .add_stop(Color::blue(), Fraction::from(0.0))
+            .add_stop(Color::white(), Fraction::from(1.0));
+
+        let sample_blue = color_scale.sample(Fraction::from(0.0), &mix).unwrap();
+        let sample_white = color_scale.sample(Fraction::from(1.0), &mix).unwrap();
+
+        assert_eq!(sample_blue, Color::blue());
+        assert_eq!(sample_white, Color::white());
+    }
+
+    #[test]
+    fn color_scale_sample() {
+        let mix = Color::mix::<Lab>;
+
+        let mut color_scale = ColorScale::empty();
+
+        color_scale
+            .add_stop(Color::green(), Fraction::from(1.0))
+            .add_stop(Color::red(), Fraction::from(0.0));
+
+        let sample_red_green = color_scale.sample(Fraction::from(0.5), &mix).unwrap();
+
+        let mix_red_green = mix(&Color::red(), &Color::green(), Fraction::from(0.5));
+
+        assert_eq!(sample_red_green, mix_red_green);
+    }
+
+    #[test]
+    fn color_scale_sample_position() {
+        let mix = Color::mix::<Lab>;
+
+        let mut color_scale = ColorScale::empty();
+
+        color_scale
+            .add_stop(Color::green(), Fraction::from(0.5))
+            .add_stop(Color::red(), Fraction::from(0.0))
+            .add_stop(Color::blue(), Fraction::from(1.0));
+
+        let sample_red = color_scale.sample(Fraction::from(0.0), &mix).unwrap();
+        let sample_green = color_scale.sample(Fraction::from(0.5), &mix).unwrap();
+        let sample_blue = color_scale.sample(Fraction::from(1.0), &mix).unwrap();
+
+        let sample_red_green = color_scale.sample(Fraction::from(0.25), &mix).unwrap();
+        let sample_green_blue = color_scale.sample(Fraction::from(0.75), &mix).unwrap();
+
+        let mix_red_green = mix(&Color::red(), &Color::green(), Fraction::from(0.50));
+        let mix_green_blue = mix(&Color::green(), &Color::blue(), Fraction::from(0.50));
+
+        assert_eq!(sample_red, Color::red());
+        assert_eq!(sample_green, Color::green());
+        assert_eq!(sample_blue, Color::blue());
+
+        assert_eq!(sample_red_green, mix_red_green);
+        assert_eq!(sample_green_blue, mix_green_blue);
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -82,10 +82,10 @@ impl Display for MaxPrecision {
 
 #[test]
 fn test_interpolate() {
-    assert_eq!(0.0, interpolate_angle(0.0, 90.0, Fraction::from(0.0)));
-    assert_eq!(45.0, interpolate_angle(0.0, 90.0, Fraction::from(0.5)));
-    assert_eq!(90.0, interpolate_angle(0.0, 90.0, Fraction::from(1.0)));
-    assert_eq!(90.0, interpolate_angle(0.0, 90.0, Fraction::from(1.1)));
+    assert_eq!(0.0, interpolate(0.0, 0.5, Fraction::from(0.0)));
+    assert_eq!(0.25, interpolate(0.0, 0.5, Fraction::from(0.5)));
+    assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.0)));
+    assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.1)));
 }
 
 #[test]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -80,27 +80,39 @@ impl Display for MaxPrecision {
     }
 }
 
-#[test]
-fn test_interpolate() {
-    assert_eq!(0.0, interpolate(0.0, 0.5, Fraction::from(0.0)));
-    assert_eq!(0.25, interpolate(0.0, 0.5, Fraction::from(0.5)));
-    assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.0)));
-    assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.1)));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
 
-#[test]
-fn test_interpolate_angle() {
-    assert_eq!(15.0, interpolate_angle(0.0, 30.0, Fraction::from(0.5)));
-    assert_eq!(20.0, interpolate_angle(0.0, 100.0, Fraction::from(0.2)));
-    assert_eq!(0.0, interpolate_angle(10.0, 350.0, Fraction::from(0.5)));
-    assert_eq!(0.0, interpolate_angle(350.0, 10.0, Fraction::from(0.5)));
-}
+    #[test]
+    fn test_mod_positive() {
+        assert_relative_eq!(0.5, mod_positive(2.9, 2.4));
+        assert_relative_eq!(1.7, mod_positive(-0.3, 2.0));
+    }
 
-#[test]
-fn test_max_precision() {
-    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5)), "0.5");
-    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.51)), "0.51");
-    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.512)), "0.512");
-    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5124)), "0.512");
-    assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5125)), "0.513");
+    #[test]
+    fn test_interpolate() {
+        assert_eq!(0.0, interpolate(0.0, 0.5, Fraction::from(0.0)));
+        assert_eq!(0.25, interpolate(0.0, 0.5, Fraction::from(0.5)));
+        assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.0)));
+        assert_eq!(0.5, interpolate(0.0, 0.5, Fraction::from(1.1)));
+    }
+
+    #[test]
+    fn test_interpolate_angle() {
+        assert_eq!(15.0, interpolate_angle(0.0, 30.0, Fraction::from(0.5)));
+        assert_eq!(20.0, interpolate_angle(0.0, 100.0, Fraction::from(0.2)));
+        assert_eq!(0.0, interpolate_angle(10.0, 350.0, Fraction::from(0.5)));
+        assert_eq!(0.0, interpolate_angle(350.0, 10.0, Fraction::from(0.5)));
+    }
+
+    #[test]
+    fn test_max_precision() {
+        assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5)), "0.5");
+        assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.51)), "0.51");
+        assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.512)), "0.512");
+        assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5124)), "0.512");
+        assert_eq!(format!("{}", MaxPrecision::wrap(3, 0.5125)), "0.513");
+    }
 }

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,0 +1,123 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    helper::{clamp, interpolate, interpolate_angle, MaxPrecision},
+    types::{Hue, Scalar},
+    Color, Format, Fraction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HSLA {
+    pub h: Scalar,
+    pub s: Scalar,
+    pub l: Scalar,
+    pub alpha: Scalar,
+}
+
+impl ColorSpace for HSLA {
+    fn from_color(c: &Color) -> Self {
+        c.to_hsla()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_hsla(self.h, self.s, self.l, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        // make sure that the hue is preserved when mixing with gray colors
+        let self_hue = if self.s < 0.0001 { other.h } else { self.h };
+        let other_hue = if other.s < 0.0001 { self.h } else { other.h };
+
+        Self {
+            h: interpolate_angle(self_hue, other_hue, fraction),
+            s: interpolate(self.s, other.s, fraction),
+            l: interpolate(self.l, other.l, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl From<&Color> for HSLA {
+    fn from(color: &Color) -> Self {
+        HSLA {
+            h: color.hue.value(),
+            s: color.saturation,
+            l: color.lightness,
+            alpha: color.alpha,
+        }
+    }
+}
+
+impl From<&HSLA> for Color {
+    fn from(color: &HSLA) -> Self {
+        Color {
+            hue: Hue::from(color.h),
+            saturation: clamp(0.0, 1.0, color.s),
+            lightness: clamp(0.0, 1.0, color.l),
+            alpha: clamp(0.0, 1.0, color.alpha),
+        }
+    }
+}
+
+impl fmt::Display for HSLA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "hsl({h}, {s}, {l})", h = self.h, s = self.s, l = self.l,)
+    }
+}
+
+impl HSLA {
+    #[inline]
+    pub fn new(h: Scalar, s: Scalar, l: Scalar) -> Self {
+        Self::with_alpha(h, s, l, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(h: Scalar, s: Scalar, l: Scalar, alpha: Scalar) -> Self {
+        HSLA { h, s, l, alpha }
+    }
+
+    /// Format the color as a HSL-representation string (`hsla(123, 50.3%, 80.1%, 0.4)`). If the
+    /// alpha channel is `1.0`, the simplified `hsl()` format will be used instead.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                ),
+            )
+        };
+        format!(
+            "hsl{a_prefix}({h:.0},{space}{s:.1}%,{space}{l:.1}%{a})",
+            space = space,
+            a_prefix = a_prefix,
+            h = self.h,
+            s = 100.0 * self.s,
+            l = 100.0 * self.l,
+            a = a,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_color_string() {
+        let c = HSLA {
+            h: 91.3,
+            s: 0.541,
+            l: 0.983,
+            alpha: 1.0,
+        };
+        assert_eq!("hsl(91, 54.1%, 98.3%)", c.to_color_string(Format::Spaces));
+        assert_eq!("hsl(91,54.1%,98.3%)", c.to_color_string(Format::NoSpaces));
+    }
+}

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -120,4 +120,17 @@ mod tests {
         assert_eq!("hsl(91, 54.1%, 98.3%)", c.to_color_string(Format::Spaces));
         assert_eq!("hsl(91,54.1%,98.3%)", c.to_color_string(Format::NoSpaces));
     }
+
+    #[test]
+    fn mixing_with_gray_preserves_hue() {
+        let hue = 123.0;
+        let base = HSLA::new(hue, 0.5, 0.5);
+
+        let hue_after_mixing = |other| base.mix(&HSLA::from(&other), Fraction::from(0.5)).h;
+
+        assert_eq!(hue, hue_after_mixing(Color::black()));
+        assert_eq!(hue, hue_after_mixing(Color::graytone(0.2)));
+        assert_eq!(hue, hue_after_mixing(Color::graytone(0.7)));
+        assert_eq!(hue, hue_after_mixing(Color::white()));
+    }
 }

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -114,15 +114,7 @@ impl HSVA {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn assert_almost_equal(c1: &Color, c2: &Color) {
-        let c1 = c1.to_rgba();
-        let c2 = c2.to_rgba();
-
-        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
-        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
-        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
-    }
+    use crate::test_helper::assert_almost_equal;
 
     #[test]
     fn hsva_conversion() {

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -83,6 +83,16 @@ impl fmt::Display for HSVA {
 }
 
 impl HSVA {
+    #[inline]
+    pub fn new(h: Scalar, s: Scalar, v: Scalar) -> Self {
+        Self::with_alpha(h, s, v, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(h: Scalar, s: Scalar, v: Scalar, alpha: Scalar) -> Self {
+        HSVA { h, s, v, alpha }
+    }
+
     /// Format the color as a HSV-representation string (`hsva(123, 50.3%, 80.1%, 0.4)`). If the
     /// alpha channel is `1.0`, the simplified `hsv()` format will be used instead.
     pub fn to_color_string(&self, format: Format) -> String {

--- a/src/hsv.rs
+++ b/src/hsv.rs
@@ -1,0 +1,145 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    helper::{clamp, interpolate, interpolate_angle, MaxPrecision},
+    types::{Hue, Scalar},
+    Color, Format, Fraction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HSVA {
+    pub h: Scalar,
+    pub s: Scalar,
+    pub v: Scalar,
+    pub alpha: Scalar,
+}
+
+impl From<&HSVA> for Color {
+    fn from(color: &HSVA) -> Self {
+        let lightness = color.v * (1.0 - color.s / 2.0);
+        let saturation = if lightness > 0.0 && lightness < 1.0 {
+            (color.v - lightness) / lightness.min(1.0 - lightness)
+        } else {
+            0.0
+        };
+
+        Color {
+            hue: Hue::from(color.h),
+            saturation: clamp(0.0, 1.0, saturation),
+            lightness: clamp(0.0, 1.0, lightness),
+            alpha: clamp(0.0, 1.0, color.alpha),
+        }
+    }
+}
+
+impl From<&Color> for HSVA {
+    fn from(color: &Color) -> Self {
+        let lightness = color.lightness;
+
+        let value = lightness + color.saturation * lightness.min(1.0 - lightness);
+        let saturation = if value > 0.0 {
+            2.0 * (1.0 - lightness / value)
+        } else {
+            0.0
+        };
+
+        HSVA {
+            h: color.hue.value(),
+            s: saturation,
+            v: value,
+            alpha: color.alpha,
+        }
+    }
+}
+
+impl ColorSpace for HSVA {
+    fn from_color(c: &Color) -> Self {
+        c.to_hsva()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_hsva(self.h, self.s, self.v, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        // make sure that the hue is preserved when mixing with gray colors
+        let self_hue = if self.s < 0.0001 { other.h } else { self.h };
+        let other_hue = if other.s < 0.0001 { self.h } else { other.h };
+
+        Self {
+            h: interpolate_angle(self_hue, other_hue, fraction),
+            s: interpolate(self.s, other.s, fraction),
+            v: interpolate(self.v, other.v, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl fmt::Display for HSVA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "hsv({h}, {s}, {v})", h = self.h, s = self.s, v = self.v)
+    }
+}
+
+impl HSVA {
+    /// Format the color as a HSV-representation string (`hsva(123, 50.3%, 80.1%, 0.4)`). If the
+    /// alpha channel is `1.0`, the simplified `hsv()` format will be used instead.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                ),
+            )
+        };
+        format!(
+            "hsv{a_prefix}({h:.0},{space}{s:.1}%,{space}{v:.1}%{a})",
+            space = space,
+            a_prefix = a_prefix,
+            h = self.h,
+            s = 100.0 * self.s,
+            v = 100.0 * self.v,
+            a = a,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_almost_equal(c1: &Color, c2: &Color) {
+        let c1 = c1.to_rgba();
+        let c2 = c2.to_rgba();
+
+        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
+        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
+        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
+    }
+
+    #[test]
+    fn hsva_conversion() {
+        assert_eq!(
+            Color::from_hsla(0.0, 1.0, 0.5, 0.5),
+            Color::from_hsva(0.0, 1.0, 1.0, 0.5)
+        );
+
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let hsva1 = color1.to_hsva();
+            let color2 = Color::from_hsva(hsva1.h, hsva1.s, hsva1.v, hsva1.alpha);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+}

--- a/src/hwb.rs
+++ b/src/hwb.rs
@@ -1,0 +1,182 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    format_css_alpha,
+    helper::{clamp, interpolate, interpolate_angle, MaxPrecision},
+    hsv::HSVA,
+    types::Scalar,
+    Color, Format, Fraction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HWBA {
+    pub h: Scalar,
+    pub w: Scalar,
+    pub b: Scalar,
+    pub alpha: Scalar,
+}
+
+impl ColorSpace for HWBA {
+    fn from_color(c: &Color) -> Self {
+        c.to_hwba()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_hwba(self.h, self.w, self.b, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        // make sure that the hue is preserved when mixing with gray colors
+        let self_hue = if (self.w + self.b) >= 1.0 {
+            other.h
+        } else {
+            self.h
+        };
+        let other_hue = if (other.w + other.b) >= 1.0 {
+            self.h
+        } else {
+            other.h
+        };
+
+        Self {
+            h: interpolate_angle(self_hue, other_hue, fraction),
+            w: interpolate(self.w, other.w, fraction),
+            b: interpolate(self.b, other.b, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl From<&Color> for HWBA {
+    fn from(color: &Color) -> Self {
+        let HSVA { h, s, v, alpha } = HSVA::from(color);
+
+        let w = (1.0 - s) * v;
+        let b = 1.0 - v;
+        HWBA { h, w, b, alpha }
+    }
+}
+
+impl From<&HWBA> for Color {
+    fn from(color: &HWBA) -> Self {
+        if color.w + color.b >= 1.0 {
+            let gray = color.w / (color.w + color.b);
+            Self::from_rgba_float(gray, gray, gray, color.alpha)
+        } else {
+            let w = clamp(0.0, 1.0, color.w);
+            let b = clamp(0.0, 1.0, color.b);
+            let v = 1.0 - b;
+            let s = 1.0 - (w / v);
+            Self::from(&HSVA::with_alpha(color.h, s, v, color.alpha))
+        }
+    }
+}
+
+impl fmt::Display for HWBA {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_color_string(Format::Spaces))
+    }
+}
+
+impl HWBA {
+    #[inline]
+    pub fn new(h: Scalar, w: Scalar, b: Scalar) -> Self {
+        Self::with_alpha(h, w, b, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(h: Scalar, w: Scalar, b: Scalar, alpha: Scalar) -> Self {
+        HWBA { h, w, b, alpha }
+    }
+
+    /// Format the color as a HWB-representation string (`hwb(123, 50.3%, 80.1%)`).
+    pub fn to_color_string(&self, format: Format) -> String {
+        format!(
+            "hwb({h:.0} {w}% {b}%{alpha})",
+            h = self.h,
+            w = MaxPrecision::wrap(1, 100.0 * self.w),
+            b = MaxPrecision::wrap(1, 100.0 * self.b),
+            alpha = format_css_alpha(self.alpha, format)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hwb_conversion() {
+        let rgbf = Color::from_rgb_float;
+        let rgb128 = 128.0 / 255.0;
+
+        assert_eq!(Color::white(), Color::from_hwb(0.0, 1.0, 0.0));
+        assert_eq!(Color::white(), Color::from_hwb(120.0, 1.0, 0.0));
+        assert_eq!(rgbf(0.5, 0.5, 0.5), Color::from_hwb(0.0, 0.5, 0.5));
+        assert_eq!(Color::gray(), Color::from_hwb(300.0, rgb128, 1.0 - rgb128));
+        assert_eq!(Color::black(), Color::from_hwb(0.0, 0.0, 1.0));
+        assert_eq!(Color::black(), Color::from_hwb(240.0, 0.0, 1.0));
+        assert_eq!(Color::red(), Color::from_hwb(0.0, 0.0, 0.0));
+        assert_eq!(
+            Color::from_hsl(60.0, 1.0, 0.375),
+            Color::from_hwb(60.0, 0.0, 0.25)
+        ); //yellow-green
+        assert_eq!(Color::green(), Color::from_hwb(120.0, 0.0, 1.0 - rgb128));
+        assert_eq!(
+            Color::from_hsl(240.0, 1.0, 0.75),
+            Color::from_hwb(240.0, 0.5, 0.0)
+        ); // blue-ish
+
+        assert_eq!(
+            Color::from_hsl(49.5, 0.8922, 0.4973),
+            Color::from_hwb(49.5, 0.0536, 0.0590)
+        ); //yellow
+        assert_eq!(
+            Color::from_hsl(162.4, 0.7794, 0.4468),
+            Color::from_hwb(162.4, 0.09856, 0.20496)
+        ); // cyan 2
+
+        assert_eq!(
+            Color::from_rgba_float(0.75, 0.0, 0.75, 0.4),
+            Color::from_hwba(300.0, 0.0, 0.25, 0.4)
+        )
+    }
+
+    #[test]
+    fn hwb_roundtrip_conversion() {
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let hwb1 = color1.to_hwba();
+            let color2 = Color::from_hwb(hwb1.h, hwb1.w, hwb1.b);
+            assert_eq!(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+
+    #[test]
+    fn to_hwb_string() {
+        let c = HWBA::new(91.0, 0.541, 0.383);
+        // modern CSS functional syntax
+        assert_eq!("hwb(91 54.1% 38.3%)", c.to_color_string(Format::Spaces));
+        // spaces are required, so NoSpaces has no effect without akpha
+        assert_eq!("hwb(91 54.1% 38.3%)", c.to_color_string(Format::NoSpaces));
+
+        let c1 = HWBA::new(91.3, 0.541, 0.383172);
+        // hue is rounded to integer, w and b are rounded to 1 decimal
+        assert_eq!("hwb(91 54.1% 38.3%)", c1.to_color_string(Format::Spaces));
+
+        let c2 = HWBA::new(90.0, 0.5, 0.25);
+        // trailing decimal zeros are not included
+        assert_eq!("hwb(90 50% 25%)", c2.to_color_string(Format::Spaces));
+
+        let c2a = HWBA::with_alpha(90.0, 0.5, 0.25, 0.8);
+        // non-unit alpha is serialized as a number
+        assert_eq!("hwb(90 50% 25% / 0.8)", c2a.to_color_string(Format::Spaces));
+        // spaces are optional around alpha separator, so NoSpaces applies
+        assert_eq!("hwb(90 50% 25%/0.8)", c2a.to_color_string(Format::NoSpaces));
+    }
+}

--- a/src/hwb.rs
+++ b/src/hwb.rs
@@ -179,4 +179,17 @@ mod tests {
         // spaces are optional around alpha separator, so NoSpaces applies
         assert_eq!("hwb(90 50% 25%/0.8)", c2a.to_color_string(Format::NoSpaces));
     }
+
+    #[test]
+    fn mixing_with_gray_preserves_hue() {
+        let hue = 123.0;
+        let base = HWBA::new(hue, 0.25, 0.25);
+
+        let hue_after_mixing = |other| base.mix(&HWBA::from(&other), Fraction::from(0.5)).h;
+
+        assert_eq!(hue, hue_after_mixing(Color::black()));
+        assert_eq!(hue, hue_after_mixing(Color::graytone(0.2)));
+        assert_eq!(hue, hue_after_mixing(Color::graytone(0.7)));
+        assert_eq!(hue, hue_after_mixing(Color::white()));
+    }
 }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -123,15 +123,7 @@ impl Lab {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn assert_almost_equal(c1: &Color, c2: &Color) {
-        let c1 = c1.to_rgba();
-        let c2 = c2.to_rgba();
-
-        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
-        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
-        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
-    }
+    use crate::test_helper::assert_almost_equal;
 
     #[test]
     fn lab_conversion() {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,0 +1,158 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    helper::{interpolate, MaxPrecision},
+    types::Scalar,
+    xyz::XYZ,
+    Color, Format, Fraction, D65_XN, D65_YN, D65_ZN,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Lab {
+    pub l: Scalar,
+    pub a: Scalar,
+    pub b: Scalar,
+    pub alpha: Scalar,
+}
+
+impl ColorSpace for Lab {
+    fn from_color(c: &Color) -> Self {
+        c.to_lab()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_lab(self.l, self.a, self.b, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        Self {
+            l: interpolate(self.l, other.l, fraction),
+            a: interpolate(self.a, other.a, fraction),
+            b: interpolate(self.b, other.b, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl From<&Color> for Lab {
+    fn from(color: &Color) -> Self {
+        let rec = XYZ::from(color);
+
+        let cut = Scalar::powf(6.0 / 29.0, 3.0);
+        let f = |t| {
+            if t > cut {
+                Scalar::powf(t, 1.0 / 3.0)
+            } else {
+                (1.0 / 3.0) * Scalar::powf(29.0 / 6.0, 2.0) * t + 4.0 / 29.0
+            }
+        };
+
+        let fy = f(rec.y / D65_YN);
+
+        let l = 116.0 * fy - 16.0;
+        let a = 500.0 * (f(rec.x / D65_XN) - fy);
+        let b = 200.0 * (fy - f(rec.z / D65_ZN));
+
+        Lab::with_alpha(l, a, b, color.alpha)
+    }
+}
+
+impl From<&Lab> for Color {
+    fn from(color: &Lab) -> Self {
+        #![allow(clippy::many_single_char_names)]
+        const DELTA: Scalar = 6.0 / 29.0;
+
+        let finv = |t| {
+            if t > DELTA {
+                Scalar::powf(t, 3.0)
+            } else {
+                3.0 * DELTA * DELTA * (t - 4.0 / 29.0)
+            }
+        };
+
+        let l_ = (color.l + 16.0) / 116.0;
+        let x = D65_XN * finv(l_ + color.a / 500.0);
+        let y = D65_YN * finv(l_);
+        let z = D65_ZN * finv(l_ - color.b / 200.0);
+
+        Self::from(&XYZ::with_alpha(x, y, z, color.alpha))
+    }
+}
+
+impl fmt::Display for Lab {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Lab({l}, {a}, {b})", l = self.l, a = self.a, b = self.b,)
+    }
+}
+
+impl Lab {
+    #[inline]
+    pub fn new(l: Scalar, a: Scalar, b: Scalar) -> Self {
+        Self::with_alpha(l, a, b, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(l: Scalar, a: Scalar, b: Scalar, alpha: Scalar) -> Self {
+        Lab { l, a, b, alpha }
+    }
+
+    /// Format the color as a Lab-representation string (`Lab(41, 83, -93, 0.5)`). If the alpha channel
+    /// is `1.0`, it won't be included in the output.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        format!(
+            "Lab({l:.0},{space}{a:.0},{space}{b:.0}{alpha})",
+            l = self.l,
+            a = self.a,
+            b = self.b,
+            space = space,
+            alpha = if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                )
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_almost_equal(c1: &Color, c2: &Color) {
+        let c1 = c1.to_rgba();
+        let c2 = c2.to_rgba();
+
+        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
+        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
+        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
+    }
+
+    #[test]
+    fn lab_conversion() {
+        assert_eq!(Color::red(), Color::from_lab(53.233, 80.109, 67.22, 1.0));
+
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let lab1 = color1.to_lab();
+            let color2 = Color::from_lab(lab1.l, lab1.a, lab1.b, 1.0);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+
+    #[test]
+    fn to_color_string() {
+        let c = Lab::new(41.0, 83.0, -93.0);
+        assert_eq!("Lab(41, 83, -93)", c.to_color_string(Format::Spaces));
+        assert_eq!("Lab(41,83,-93)", c.to_color_string(Format::NoSpaces));
+    }
+}

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -107,15 +107,7 @@ impl LCh {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn assert_almost_equal(c1: &Color, c2: &Color) {
-        let c1 = c1.to_rgba();
-        let c2 = c2.to_rgba();
-
-        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
-        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
-        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
-    }
+    use crate::test_helper::assert_almost_equal;
 
     #[test]
     fn lch_conversion() {

--- a/src/lch.rs
+++ b/src/lch.rs
@@ -1,0 +1,145 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    helper::{interpolate, interpolate_angle, mod_positive, MaxPrecision},
+    lab::Lab,
+    types::Scalar,
+    Color, Format, Fraction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LCh {
+    pub l: Scalar,
+    pub c: Scalar,
+    pub h: Scalar,
+    pub alpha: Scalar,
+}
+
+impl ColorSpace for LCh {
+    fn from_color(c: &Color) -> Self {
+        c.to_lch()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_lch(self.l, self.c, self.h, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        // make sure that the hue is preserved when mixing with gray colors
+        let self_hue = if self.c < 0.1 { other.h } else { self.h };
+        let other_hue = if other.c < 0.1 { self.h } else { other.h };
+
+        Self {
+            l: interpolate(self.l, other.l, fraction),
+            c: interpolate(self.c, other.c, fraction),
+            h: interpolate_angle(self_hue, other_hue, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl From<&Color> for LCh {
+    fn from(color: &Color) -> Self {
+        let Lab { l, a, b, alpha } = Lab::from(color);
+
+        const RAD2DEG: Scalar = 180.0 / std::f64::consts::PI;
+
+        let c = Scalar::sqrt(a * a + b * b);
+        let h = mod_positive(Scalar::atan2(b, a) * RAD2DEG, 360.0);
+
+        LCh::with_alpha(l, c, h, alpha)
+    }
+}
+
+impl From<&LCh> for Color {
+    fn from(color: &LCh) -> Self {
+        #![allow(clippy::many_single_char_names)]
+        const DEG2RAD: Scalar = std::f64::consts::PI / 180.0;
+
+        let a = color.c * Scalar::cos(color.h * DEG2RAD);
+        let b = color.c * Scalar::sin(color.h * DEG2RAD);
+
+        Self::from(&Lab::with_alpha(color.l, a, b, color.alpha))
+    }
+}
+
+impl fmt::Display for LCh {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LCh({l}, {c}, {h})", l = self.l, c = self.c, h = self.h,)
+    }
+}
+
+impl LCh {
+    #[inline]
+    pub fn new(l: Scalar, c: Scalar, h: Scalar) -> Self {
+        Self::with_alpha(l, c, h, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(l: Scalar, c: Scalar, h: Scalar, alpha: Scalar) -> Self {
+        LCh { l, c, h, alpha }
+    }
+
+    /// Format the color as a Lab-representation string (`Lab(41, 83, -93, 0.5)`). If the alpha channel
+    /// is `1.0`, it won't be included in the output.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        format!(
+            "LCh({l:.0},{space}{c:.0},{space}{h:.0}{alpha})",
+            l = self.l,
+            c = self.c,
+            h = self.h,
+            space = space,
+            alpha = if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                )
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_almost_equal(c1: &Color, c2: &Color) {
+        let c1 = c1.to_rgba();
+        let c2 = c2.to_rgba();
+
+        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
+        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
+        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
+    }
+
+    #[test]
+    fn lch_conversion() {
+        assert_eq!(
+            Color::from_hsl(0.0, 1.0, 0.245),
+            Color::from_lch(24.829, 60.093, 38.18, 1.0)
+        );
+
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let lch1 = color1.to_lch();
+            let color2 = Color::from_lch(lch1.l, lch1.c, lch1.h, 1.0);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+
+    #[test]
+    fn to_color_string() {
+        let c = LCh::new(52.0, 44.0, 271.0);
+        assert_eq!("LCh(52, 44, 271)", c.to_color_string(Format::Spaces));
+        assert_eq!("LCh(52,44,271)", c.to_color_string(Format::NoSpaces));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ansi;
 pub mod cmyk;
+pub mod color_scale;
 pub mod colorspace;
 pub mod convert;
 pub mod delta_e;
@@ -24,7 +25,6 @@ mod test_helper;
 
 use std::{fmt, str::FromStr};
 
-// Re-export color space types
 pub use cmyk::CMYK;
 pub use hsl::HSLA;
 pub use hsv::HSVA;
@@ -39,6 +39,8 @@ use colorspace::ColorSpace;
 pub use helper::Fraction;
 use helper::MaxPrecision;
 use types::{Hue, Scalar};
+
+pub use color_scale::ColorScale;
 
 /// The representation of a color.
 ///
@@ -682,96 +684,6 @@ pub enum Format {
     NoSpaces,
 }
 
-/// The representation of a color stop for a `ColorScale`.
-/// The position defines where the color is placed from left (0.0) to right (1.0).
-#[derive(Debug, Clone)]
-struct ColorStop {
-    color: Color,
-    position: Fraction,
-}
-
-/// The representation of a color scale.
-/// The first `ColorStop` (position 0.0) defines the left end color.
-/// The last `ColorStop` (position 1.0) defines the right end color.
-#[derive(Debug, Clone)]
-pub struct ColorScale {
-    color_stops: Vec<ColorStop>,
-}
-
-impl ColorScale {
-    /// Create an empty `ColorScale`.
-    pub fn empty() -> Self {
-        Self {
-            color_stops: Vec::new(),
-        }
-    }
-
-    /// Add a `Color` at the given position.
-    pub fn add_stop(&mut self, color: Color, position: Fraction) -> &mut Self {
-        #![allow(clippy::float_cmp)]
-        let same_position = self
-            .color_stops
-            .iter_mut()
-            .find(|c| position.value() == c.position.value());
-
-        match same_position {
-            Some(color_stop) => color_stop.color = color,
-            None => {
-                let next_index = self
-                    .color_stops
-                    .iter()
-                    .position(|c| position.value() < c.position.value());
-
-                let index = next_index.unwrap_or(self.color_stops.len());
-
-                let color_stop = ColorStop { color, position };
-
-                self.color_stops.insert(index, color_stop);
-            }
-        };
-
-        self
-    }
-
-    /// Get the color at the given position using the mixing function.
-    ///
-    /// Note:
-    /// - No color is returned if position isn't between two color stops or the `ColorScale` is empty.
-    pub fn sample(
-        &self,
-        position: Fraction,
-        mix: &dyn Fn(&Color, &Color, Fraction) -> Color,
-    ) -> Option<Color> {
-        if self.color_stops.len() < 2 {
-            return None;
-        }
-
-        let left_stop = self
-            .color_stops
-            .iter()
-            .rev()
-            .find(|c| position.value() >= c.position.value());
-
-        let right_stop = self
-            .color_stops
-            .iter()
-            .find(|c| position.value() <= c.position.value());
-
-        match (left_stop, right_stop) {
-            (Some(left_stop), Some(right_stop)) => {
-                let diff_color_stops = right_stop.position.value() - left_stop.position.value();
-                let diff_position = position.value() - left_stop.position.value();
-                let local_position = Fraction::from(diff_position / diff_color_stops);
-
-                let color = mix(&left_stop.color, &right_stop.color, local_position);
-
-                Some(color)
-            }
-            _ => None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -989,109 +901,6 @@ mod tests {
 
         let mix_in_hwb = |other| input.mix::<HWBA>(&other, Fraction::from(0.5));
         assert_eq!(hue, mix_in_hwb(Color::graytone(0.5)).hue.value());
-    }
-
-    #[test]
-    fn color_scale_add_preserves_ordering() {
-        let mut color_scale = ColorScale::empty();
-
-        color_scale
-            .add_stop(Color::red(), Fraction::from(0.5))
-            .add_stop(Color::gray(), Fraction::from(0.0))
-            .add_stop(Color::blue(), Fraction::from(1.0));
-
-        assert_eq!(color_scale.color_stops.get(0).unwrap().color, Color::gray());
-        assert_eq!(color_scale.color_stops.get(1).unwrap().color, Color::red());
-        assert_eq!(color_scale.color_stops.get(2).unwrap().color, Color::blue());
-    }
-
-    #[test]
-    fn color_scale_empty_sample_none() {
-        let mix = Color::mix::<Lab>;
-
-        let color_scale = ColorScale::empty();
-
-        let color = color_scale.sample(Fraction::from(0.0), &mix);
-
-        assert_eq!(color, None);
-    }
-
-    #[test]
-    fn color_scale_one_color_sample_none() {
-        let mix = Color::mix::<Lab>;
-
-        let mut color_scale = ColorScale::empty();
-
-        color_scale.add_stop(Color::red(), Fraction::from(0.0));
-
-        let color = color_scale.sample(Fraction::from(0.0), &mix);
-
-        assert_eq!(color, None);
-    }
-
-    #[test]
-    fn color_scale_sample_same_position() {
-        let mix = Color::mix::<Lab>;
-
-        let mut color_scale = ColorScale::empty();
-
-        color_scale
-            .add_stop(Color::red(), Fraction::from(0.0))
-            .add_stop(Color::green(), Fraction::from(1.0))
-            .add_stop(Color::blue(), Fraction::from(0.0))
-            .add_stop(Color::white(), Fraction::from(1.0));
-
-        let sample_blue = color_scale.sample(Fraction::from(0.0), &mix).unwrap();
-        let sample_white = color_scale.sample(Fraction::from(1.0), &mix).unwrap();
-
-        assert_eq!(sample_blue, Color::blue());
-        assert_eq!(sample_white, Color::white());
-    }
-
-    #[test]
-    fn color_scale_sample() {
-        let mix = Color::mix::<Lab>;
-
-        let mut color_scale = ColorScale::empty();
-
-        color_scale
-            .add_stop(Color::green(), Fraction::from(1.0))
-            .add_stop(Color::red(), Fraction::from(0.0));
-
-        let sample_red_green = color_scale.sample(Fraction::from(0.5), &mix).unwrap();
-
-        let mix_red_green = mix(&Color::red(), &Color::green(), Fraction::from(0.5));
-
-        assert_eq!(sample_red_green, mix_red_green);
-    }
-
-    #[test]
-    fn color_scale_sample_position() {
-        let mix = Color::mix::<Lab>;
-
-        let mut color_scale = ColorScale::empty();
-
-        color_scale
-            .add_stop(Color::green(), Fraction::from(0.5))
-            .add_stop(Color::red(), Fraction::from(0.0))
-            .add_stop(Color::blue(), Fraction::from(1.0));
-
-        let sample_red = color_scale.sample(Fraction::from(0.0), &mix).unwrap();
-        let sample_green = color_scale.sample(Fraction::from(0.5), &mix).unwrap();
-        let sample_blue = color_scale.sample(Fraction::from(1.0), &mix).unwrap();
-
-        let sample_red_green = color_scale.sample(Fraction::from(0.25), &mix).unwrap();
-        let sample_green_blue = color_scale.sample(Fraction::from(0.75), &mix).unwrap();
-
-        let mix_red_green = mix(&Color::red(), &Color::green(), Fraction::from(0.50));
-        let mix_green_blue = mix(&Color::green(), &Color::blue(), Fraction::from(0.50));
-
-        assert_eq!(sample_red, Color::red());
-        assert_eq!(sample_green, Color::green());
-        assert_eq!(sample_blue, Color::blue());
-
-        assert_eq!(sample_red_green, mix_red_green);
-        assert_eq!(sample_green_blue, mix_green_blue);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub mod random;
 mod types;
 pub mod xyz;
 
+#[cfg(test)]
+mod test_helper;
+
 use std::{fmt, str::FromStr};
 
 // Re-export color space types
@@ -1163,16 +1166,8 @@ impl ColorScale {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helper::assert_almost_equal;
     use approx::assert_relative_eq;
-
-    fn assert_almost_equal(c1: &Color, c2: &Color) {
-        let c1 = c1.to_rgba();
-        let c2 = c2.to_rgba();
-
-        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
-        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
-        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
-    }
 
     #[test]
     fn color_partial_eq() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,31 +75,24 @@ fn format_css_alpha(alpha: Scalar, format: Format) -> String {
 }
 
 impl Color {
+    #[inline]
     pub fn from_hsla(hue: Scalar, saturation: Scalar, lightness: Scalar, alpha: Scalar) -> Color {
         Self::from(&HSLA::with_alpha(hue, saturation, lightness, alpha))
     }
 
-    ///
+    #[inline]
     pub fn from_hsl(hue: Scalar, saturation: Scalar, lightness: Scalar) -> Color {
         Self::from(&HSLA::new(hue, saturation, lightness))
     }
 
+    #[inline]
     pub fn from_hsva(hue: Scalar, saturation: Scalar, value: Scalar, alpha: Scalar) -> Color {
-        Self::from(&HSVA {
-            h: hue,
-            s: saturation,
-            v: value,
-            alpha,
-        })
+        Self::from(&HSVA::with_alpha(hue, saturation, value, alpha))
     }
 
+    #[inline]
     pub fn from_hsv(hue: Scalar, saturation: Scalar, value: Scalar) -> Color {
-        Self::from(&HSVA {
-            h: hue,
-            s: saturation,
-            v: value,
-            alpha: 1.0,
-        })
+        Self::from(&HSVA::new(hue, saturation, value))
     }
 
     /// Create a `Color` from a hue, and whiteness and blackness values with a
@@ -107,53 +100,44 @@ impl Color {
     ///
     /// See:
     /// - https://en.wikipedia.org/wiki/HWB_color_model
+    #[inline]
     pub fn from_hwba(hue: Scalar, whiteness: Scalar, blackness: Scalar, alpha: Scalar) -> Color {
-        Self::from(&HWBA {
-            h: hue,
-            w: whiteness,
-            b: blackness,
-            alpha,
-        })
+        Self::from(&HWBA::with_alpha(hue, whiteness, blackness, alpha))
     }
 
     /// Create a `Color` from a hue, and whiteness and blackness values.
+    #[inline]
     pub fn from_hwb(hue: Scalar, whiteness: Scalar, blackness: Scalar) -> Color {
-        Self::from_hwba(hue, whiteness, blackness, 1.0)
+        Self::from(&HWBA::new(hue, whiteness, blackness))
     }
 
     /// Create a `Color` from integer RGB values between 0 and 255 and a floating
     /// point alpha value between 0.0 and 1.0.
+    #[inline]
     pub fn from_rgba(r: u8, g: u8, b: u8, alpha: Scalar) -> Color {
         // RGB to HSL conversion algorithm adapted from
         // https://en.wikipedia.org/wiki/HSL_and_HSV
-        Self::from(&RGBA::<u8> { r, g, b, alpha })
+        Self::from(&RGBA::with_alpha(r, g, b, alpha))
     }
 
     /// Create a `Color` from integer RGB values between 0 and 255.
+    #[inline]
     pub fn from_rgb(r: u8, g: u8, b: u8) -> Color {
-        Self::from(&RGBA::<u8> {
-            r,
-            g,
-            b,
-            alpha: 1.0,
-        })
+        Self::from(&RGBA::new(r, g, b))
     }
 
     /// Create a `Color` from RGB and alpha values between 0.0 and 1.0. Values outside this range
     /// will be clamped.
+    #[inline]
     pub fn from_rgba_float(r: Scalar, g: Scalar, b: Scalar, alpha: Scalar) -> Color {
-        Self::from(&RGBA::<f64> { r, g, b, alpha })
+        Self::from(&RGBA::with_alpha(r, g, b, alpha))
     }
 
     /// Create a `Color` from RGB values between 0.0 and 1.0. Values outside this range will be
     /// clamped.
+    #[inline]
     pub fn from_rgb_float(r: Scalar, g: Scalar, b: Scalar) -> Color {
-        Self::from(&RGBA::<f64> {
-            r,
-            g,
-            b,
-            alpha: 1.0,
-        })
+        Self::from(&RGBA::new(r, g, b))
     }
 
     /// Create a `Color` from XYZ coordinates in the CIE 1931 color space. Note that a `Color`
@@ -165,12 +149,14 @@ impl Color {
     /// See:
     /// - <https://en.wikipedia.org/wiki/CIE_1931_color_space>
     /// - <https://en.wikipedia.org/wiki/SRGB>
+    #[inline]
     pub fn from_xyz(x: Scalar, y: Scalar, z: Scalar, alpha: Scalar) -> Color {
         Self::from(&XYZ::with_alpha(x, y, z, alpha))
     }
 
     /// Create a `Color` from LMS coordinates. This is the matrix inverse of the matrix that
     /// appears in `to_lms`.
+    #[inline]
     pub fn from_lms(l: Scalar, m: Scalar, s: Scalar, alpha: Scalar) -> Color {
         Self::from(&LMS::with_alpha(l, m, s, alpha))
     }
@@ -179,6 +165,7 @@ impl Color {
     /// space. Note: See documentation for `from_xyz`. The same restrictions apply here.
     ///
     /// See: <https://en.wikipedia.org/wiki/Lab_color_space>
+    #[inline]
     pub fn from_lab(l: Scalar, a: Scalar, b: Scalar, alpha: Scalar) -> Color {
         Self::from(&Lab::with_alpha(l, a, b, alpha))
     }
@@ -188,12 +175,14 @@ impl Color {
     /// `from_xyz`. The same restrictions apply here.
     ///
     /// See: <https://en.wikipedia.org/wiki/Lab_color_space>
+    #[inline]
     pub fn from_lch(l: Scalar, c: Scalar, h: Scalar, alpha: Scalar) -> Color {
         Self::from(&LCh::with_alpha(l, c, h, alpha))
     }
 
     /// Create a `Color` from  the four colours of the CMYK model: Cyan, Magenta, Yellow and Black.
     /// The CMYK colours are subtractive. This means the colours get darker as you blend them together
+    #[inline]
     pub fn from_cmyk(c: Scalar, m: Scalar, y: Scalar, k: Scalar) -> Color {
         Self::from(&CMYK::new(c, m, y, k))
     }
@@ -201,85 +190,91 @@ impl Color {
     /// Convert a `Color` to its hue, saturation, lightness and alpha values. The hue is given
     /// in degrees, as a number between 0.0 and 360.0. Saturation, lightness and alpha are numbers
     /// between 0.0 and 1.0.
+    #[inline]
     pub fn to_hsla(&self) -> HSLA {
         HSLA::from(self)
     }
 
     /// Format the color as a HSL-representation string (`hsla(123, 50.3%, 80.1%, 0.4)`). If the
     /// alpha channel is `1.0`, the simplified `hsl()` format will be used instead.
+    #[inline]
     pub fn to_hsl_string(&self, format: Format) -> String {
-        let hsl = self.to_hsla();
-        hsl.to_color_string(format)
+        HSLA::from(self).to_color_string(format)
     }
 
     /// Convert a `Color` to its hue, saturation, value and alpha values. The hue is given
     /// in degrees, as a number between 0.0 and 360.0. Saturation, value and alpha are numbers
     /// between 0.0 and 1.0.
+    #[inline]
     pub fn to_hsva(&self) -> HSVA {
         HSVA::from(self)
     }
 
     /// Format the color as a HSV-representation string (`hsva(123, 50.3%, 80.1%, 0.4)`). If the
     /// alpha channel is `1.0`, the simplified `hsv()` format will be used instead.
+    #[inline]
     pub fn to_hsv_string(&self, format: Format) -> String {
-        let hsv = HSVA::from(self);
-        hsv.to_color_string(format)
+        HSVA::from(self).to_color_string(format)
     }
 
     /// Convert a `Color` to its hue, whiteness, blackness, and alpha values. The hue is given in
     /// degrees, as a number between 0.0 and 360.0. Whiteness, blackness, and alpha are numbers
     /// between 0.0 and 1.0.
+    #[inline]
     pub fn to_hwba(&self) -> HWBA {
         HWBA::from(self)
     }
 
     /// Format the color as a HWB-representation string (`hwb(123, 50.3%, 80.1%)`).
+    #[inline]
     pub fn to_hwb_string(&self, format: Format) -> String {
-        let hwb = HWBA::from(self);
-        hwb.to_color_string(format)
+        HWBA::from(self).to_color_string(format)
     }
 
     /// Convert a `Color` to its red, green, blue and alpha values. The RGB values are integers in
     /// the range from 0 to 255. The alpha channel is a number between 0.0 and 1.0.
+    #[inline]
     pub fn to_rgba(&self) -> RGBA<u8> {
         RGBA::<u8>::from(self)
     }
 
     /// Format the color as a RGB-representation string (`rgba(255, 127, 0, 0.5)`). If the alpha channel
     /// is `1.0`, the simplified `rgb()` format will be used instead.
+    #[inline]
     pub fn to_rgb_string(&self, format: Format) -> String {
-        let rgba = RGBA::<u8>::from(self);
-        rgba.to_color_string(format)
+        RGBA::<u8>::from(self).to_color_string(format)
     }
 
     /// Convert a `Color` to its cyan, magenta, yellow, and black values. The CMYK
     /// values are floats smaller than or equal to 1.0.
+    #[inline]
     pub fn to_cmyk(&self) -> CMYK {
         CMYK::from(self)
     }
 
     /// Format the color as a CMYK-representation string (`cmyk(0, 50, 100, 100)`).
+    #[inline]
     pub fn to_cmyk_string(&self, format: Format) -> String {
-        let cmyk = CMYK::from(self);
-        cmyk.to_color_string(format)
+        CMYK::from(self).to_color_string(format)
     }
 
     /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5, 0)`). If the alpha channel
     /// is `1.0`, the simplified `rgb()` format will be used instead.
+    #[inline]
     pub fn to_rgb_float_string(&self, format: Format) -> String {
-        let rgba = self.to_rgba_float();
-        rgba.to_color_string(format)
+        RGBA::<f64>::from(self).to_color_string(format)
     }
 
     /// Format the color as a RGB-representation string (`#fc0070`). The output will contain 6 hex
     /// digits if the alpha channel is `1.0`, or 8 hex digits otherwise.
+    #[inline]
     pub fn to_rgb_hex_string(&self, leading_hash: bool) -> String {
-        let rgba = self.to_rgba();
-        rgba.to_hex_string(leading_hash)
+        RGBA::<u8>::from(self).to_hex_string(leading_hash)
     }
 
     /// Convert a `Color` to its red, green, blue and alpha values. All numbers are from the range
     /// between 0.0 and 1.0.
+    #[inline]
     pub fn to_rgba_float(&self) -> RGBA<Scalar> {
         RGBA::<f64>::from(self)
     }
@@ -295,6 +290,7 @@ impl Color {
     /// See:
     /// - <https://en.wikipedia.org/wiki/CIE_1931_color_space>
     /// - <https://en.wikipedia.org/wiki/SRGB>
+    #[inline]
     pub fn to_xyz(&self) -> XYZ {
         XYZ::from(self)
     }
@@ -303,6 +299,7 @@ impl Color {
     ///
     /// See <https://en.wikipedia.org/wiki/LMS_color_space> for info on the color space as well as an
     /// algorithm for converting from CIE XYZ
+    #[inline]
     pub fn to_lms(&self) -> LMS {
         LMS::from(self)
     }
@@ -310,29 +307,31 @@ impl Color {
     /// Get L, a and b coordinates according to the Lab color space.
     ///
     /// See: <https://en.wikipedia.org/wiki/Lab_color_space>
+    #[inline]
     pub fn to_lab(&self) -> Lab {
         Lab::from(self)
     }
 
     /// Format the color as a Lab-representation string (`Lab(41, 83, -93, 0.5)`). If the alpha channel
     /// is `1.0`, it won't be included in the output.
+    #[inline]
     pub fn to_lab_string(&self, format: Format) -> String {
-        let lab = Lab::from(self);
-        lab.to_color_string(format)
+        Lab::from(self).to_color_string(format)
     }
 
     /// Get L, C and h coordinates according to the CIE LCh color space.
     ///
     /// See: <https://en.wikipedia.org/wiki/Lab_color_space>
+    #[inline]
     pub fn to_lch(&self) -> LCh {
         LCh::from(self)
     }
 
     /// Format the color as a LCh-representation string (`LCh(0.3, 0.2, 0.1, 0.5)`). If the alpha channel
     /// is `1.0`, it won't be included in the output.
+    #[inline]
     pub fn to_lch_string(&self, format: Format) -> String {
-        let lch = LCh::from(self);
-        lch.to_color_string(format)
+        LCh::from(self).to_color_string(format)
     }
 
     /// Pure black.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ansi;
+pub mod cmyk;
 pub mod colorspace;
 pub mod convert;
 pub mod delta_e;
@@ -23,6 +24,7 @@ mod test_helper;
 use std::{fmt, str::FromStr};
 
 // Re-export color space types
+pub use cmyk::CMYK;
 pub use hsl::HSLA;
 pub use hsv::HSVA;
 pub use hwb::HWBA;
@@ -192,7 +194,7 @@ impl Color {
     /// Create a `Color` from  the four colours of the CMYK model: Cyan, Magenta, Yellow and Black.
     /// The CMYK colours are subtractive. This means the colours get darker as you blend them together
     pub fn from_cmyk(c: Scalar, m: Scalar, y: Scalar, k: Scalar) -> Color {
-        Self::from(&CMYK { c, m, y, k })
+        Self::from(&CMYK::new(c, m, y, k))
     }
 
     /// Convert a `Color` to its hue, saturation, lightness and alpha values. The hue is given
@@ -258,14 +260,7 @@ impl Color {
     /// Format the color as a CMYK-representation string (`cmyk(0, 50, 100, 100)`).
     pub fn to_cmyk_string(&self, format: Format) -> String {
         let cmyk = CMYK::from(self);
-        format!(
-            "cmyk({c},{space}{m},{space}{y},{space}{k})",
-            c = (cmyk.c * 100.0).round(),
-            m = (cmyk.m * 100.0).round(),
-            y = (cmyk.y * 100.0).round(),
-            k = (cmyk.k * 100.0).round(),
-            space = if format == Format::Spaces { " " } else { "" }
-        )
+        cmyk.to_color_string(format)
     }
 
     /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5, 0)`). If the alpha channel
@@ -684,23 +679,6 @@ impl From<&LMS> for Color {
     }
 }
 
-// from CMYK to Color so you can do -> let new_color = Color::from(&some_cmyk);
-impl From<&CMYK> for Color {
-    fn from(color: &CMYK) -> Self {
-        #![allow(clippy::many_single_char_names)]
-        let r = (1.0 - color.c) * (1.0 - color.k);
-        let g = (1.0 - color.m) * (1.0 - color.k);
-        let b = (1.0 - color.y) * (1.0 - color.k);
-
-        Color::from(&RGBA::<f64> {
-            r,
-            g,
-            b,
-            alpha: 1.0,
-        })
-    }
-}
-
 /// A color space whose axes correspond to the responsivity spectra of the long-, medium-, and
 /// short-wavelength cone cells in the human eye. More info
 /// [here](https://en.wikipedia.org/wiki/LMS_color_space).
@@ -731,54 +709,6 @@ impl From<&Color> for LMS {
 impl fmt::Display for LMS {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "LMS({l}, {m}, {s})", l = self.l, m = self.m, s = self.s,)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct CMYK {
-    pub c: Scalar,
-    pub m: Scalar,
-    pub y: Scalar,
-    pub k: Scalar,
-}
-
-impl From<&Color> for CMYK {
-    fn from(color: &Color) -> Self {
-        let rgba = RGBA::<u8>::from(color);
-        let r = (rgba.r as f64) / 255.0;
-        let g = (rgba.g as f64) / 255.0;
-        let b = (rgba.b as f64) / 255.0;
-        let biggest = if r >= g && r >= b {
-            r
-        } else if g >= r && g >= b {
-            g
-        } else {
-            b
-        };
-        let out_k = 1.0 - biggest;
-        let out_c = (1.0 - r - out_k) / biggest;
-        let out_m = (1.0 - g - out_k) / biggest;
-        let out_y = (1.0 - b - out_k) / biggest;
-
-        CMYK {
-            c: if out_c.is_nan() { 0.0 } else { out_c },
-            m: if out_m.is_nan() { 0.0 } else { out_m },
-            y: if out_y.is_nan() { 0.0 } else { out_y },
-            k: out_k,
-        }
-    }
-}
-
-impl fmt::Display for CMYK {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "cmyk({c}, {m}, {y}, {k})",
-            c = self.c,
-            m = self.m,
-            y = self.y,
-            k = self.k,
-        )
     }
 }
 
@@ -1275,23 +1205,14 @@ mod tests {
 
     #[test]
     fn to_cmyk_string() {
-        let white = Color::from_rgb(255, 255, 255);
-        assert_eq!("cmyk(0, 0, 0, 0)", white.to_cmyk_string(Format::Spaces));
-
         let black = Color::from_rgb(0, 0, 0);
         assert_eq!("cmyk(0, 0, 0, 100)", black.to_cmyk_string(Format::Spaces));
 
-        let c = Color::from_rgb(19, 19, 1);
-        assert_eq!("cmyk(0, 0, 95, 93)", c.to_cmyk_string(Format::Spaces));
+        let gray = Color::from_rgb(55, 55, 55);
+        assert_eq!("cmyk(0, 0, 0, 78)", gray.to_cmyk_string(Format::Spaces));
 
-        let c1 = Color::from_rgb(55, 55, 55);
-        assert_eq!("cmyk(0, 0, 0, 78)", c1.to_cmyk_string(Format::Spaces));
-
-        let c2 = Color::from_rgb(136, 117, 78);
-        assert_eq!("cmyk(0, 14, 43, 47)", c2.to_cmyk_string(Format::Spaces));
-
-        let c3 = Color::from_rgb(143, 111, 76);
-        assert_eq!("cmyk(0, 22, 47, 44)", c3.to_cmyk_string(Format::Spaces));
+        let c = Color::from_rgb(136, 117, 78);
+        assert_eq!("cmyk(0, 14, 43, 47)", c.to_cmyk_string(Format::Spaces));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,31 +816,6 @@ mod tests {
     }
 
     #[test]
-    fn rgb_to_hsl_conversion() {
-        assert_eq!(Color::white(), Color::from_rgb_float(1.0, 1.0, 1.0));
-        assert_eq!(Color::gray(), Color::from_rgb_float(0.5, 0.5, 0.5));
-        assert_eq!(Color::black(), Color::from_rgb_float(0.0, 0.0, 0.0));
-        assert_eq!(Color::red(), Color::from_rgb_float(1.0, 0.0, 0.0));
-        assert_eq!(
-            Color::from_hsl(60.0, 1.0, 0.375),
-            Color::from_rgb_float(0.75, 0.75, 0.0)
-        ); //yellow-green
-        assert_eq!(Color::green(), Color::from_rgb_float(0.0, 0.5, 0.0));
-        assert_eq!(
-            Color::from_hsl(240.0, 1.0, 0.75),
-            Color::from_rgb_float(0.5, 0.5, 1.0)
-        ); // blue-ish
-        assert_eq!(
-            Color::from_hsl(49.5, 0.893, 0.497),
-            Color::from_rgb_float(0.941, 0.785, 0.053)
-        ); // yellow
-        assert_eq!(
-            Color::from_hsl(162.4, 0.779, 0.447),
-            Color::from_rgb_float(0.099, 0.795, 0.591)
-        ); // cyan 2
-    }
-
-    #[test]
     fn to_u32() {
         assert_eq!(0, Color::black().to_u32());
         assert_eq!(0xff0000, Color::red().to_u32());
@@ -977,8 +952,13 @@ mod tests {
     #[test]
     fn to_rgb_hex_string() {
         let c = Color::from_rgb(255, 127, 4);
-        assert_eq!("ff7f04", c.to_rgb_hex_string(false));
         assert_eq!("#ff7f04", c.to_rgb_hex_string(true));
+    }
+
+    #[test]
+    fn to_cmyk_string() {
+        let c = Color::from_rgb(136, 117, 78);
+        assert_eq!("cmyk(0, 14, 43, 47)", c.to_cmyk_string(Format::Spaces));
     }
 
     #[test]
@@ -1000,37 +980,13 @@ mod tests {
     #[test]
     fn mixing_with_gray_preserves_hue() {
         let hue = 123.0;
-
         let input = Color::from_hsla(hue, 0.5, 0.5, 1.0);
 
-        let hue_after_mixing = |other| input.mix::<HSLA>(&other, Fraction::from(0.5)).to_hsla().h;
+        let mix_in_hsl = |other| input.mix::<HSLA>(&other, Fraction::from(0.5));
+        assert_eq!(hue, mix_in_hsl(Color::graytone(0.5)).hue.value());
 
-        assert_eq!(hue, hue_after_mixing(Color::black()));
-        assert_eq!(hue, hue_after_mixing(Color::graytone(0.2)));
-        assert_eq!(hue, hue_after_mixing(Color::graytone(0.7)));
-        assert_eq!(hue, hue_after_mixing(Color::white()));
-    }
-
-    #[test]
-    fn mixing_with_gray_in_hwb_preserves_hue() {
-        let hue = 123.0;
-
-        let input = Color::from_hsla(hue, 0.5, 0.5, 1.0);
-
-        let hue_after_mixing = |other| input.mix::<HWBA>(&other, Fraction::from(0.5)).to_hsla().h;
-
-        assert_relative_eq!(hue, hue_after_mixing(Color::black()), epsilon = 1.0e-6);
-        assert_relative_eq!(
-            hue,
-            hue_after_mixing(Color::graytone(0.2)),
-            epsilon = 1.0e-6
-        );
-        assert_relative_eq!(
-            hue,
-            hue_after_mixing(Color::graytone(0.7)),
-            epsilon = 1.0e-6
-        );
-        assert_relative_eq!(hue, hue_after_mixing(Color::white()), epsilon = 1.0e-6);
+        let mix_in_hwb = |other| input.mix::<HWBA>(&other, Fraction::from(0.5));
+        assert_eq!(hue, mix_in_hwb(Color::graytone(0.5)).hue.value());
     }
 
     #[test]
@@ -1134,18 +1090,6 @@ mod tests {
 
         assert_eq!(sample_red_green, mix_red_green);
         assert_eq!(sample_green_blue, mix_green_blue);
-    }
-
-    #[test]
-    fn to_cmyk_string() {
-        let black = Color::from_rgb(0, 0, 0);
-        assert_eq!("cmyk(0, 0, 0, 100)", black.to_cmyk_string(Format::Spaces));
-
-        let gray = Color::from_rgb(55, 55, 55);
-        assert_eq!("cmyk(0, 0, 0, 78)", gray.to_cmyk_string(Format::Spaces));
-
-        let c = Color::from_rgb(136, 117, 78);
-        assert_eq!("cmyk(0, 14, 43, 47)", c.to_cmyk_string(Format::Spaces));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,9 @@ impl Color {
     }
 
     /// Return the color as an integer in RGB representation (`0xRRGGBB`)
+    #[inline]
     pub fn to_u32(&self) -> u32 {
-        let rgba = self.to_rgba();
-        u32::from(rgba.r).wrapping_shl(16) + u32::from(rgba.g).wrapping_shl(8) + u32::from(rgba.b)
+        self.to_rgba().to_u32()
     }
 
     /// Get XYZ coordinates according to the CIE 1931 color space.
@@ -822,10 +822,7 @@ mod tests {
 
     #[test]
     fn to_u32() {
-        assert_eq!(0, Color::black().to_u32());
-        assert_eq!(0xff0000, Color::red().to_u32());
-        assert_eq!(0xffffff, Color::white().to_u32());
-        assert_eq!(0xf4230f, Color::from_rgb(0xf4, 0x23, 0x0f).to_u32());
+        assert_eq!(0xff00ff, Color::fuchsia().to_u32());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod matrix;
 pub mod named;
 pub mod parser;
 pub mod random;
+pub mod rgb;
 mod types;
 pub mod xyz;
 
@@ -25,11 +26,12 @@ pub use hsl::HSLA;
 pub use hsv::HSVA;
 pub use lab::Lab;
 pub use lch::LCh;
+pub use rgb::RGBA;
 pub use xyz::XYZ;
 
 use colorspace::ColorSpace;
 pub use helper::Fraction;
-use helper::{clamp, interpolate, interpolate_angle, mod_positive, MaxPrecision};
+use helper::{clamp, interpolate, interpolate_angle, MaxPrecision};
 use matrix::mat3_dot;
 use types::{Hue, Mat3, Scalar};
 
@@ -248,28 +250,7 @@ impl Color {
     /// is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_rgb_string(&self, format: Format) -> String {
         let rgba = RGBA::<u8>::from(self);
-        let space = if format == Format::Spaces { " " } else { "" };
-        let (a_prefix, a) = if self.alpha == 1.0 {
-            ("", "".to_string())
-        } else {
-            (
-                "a",
-                format!(
-                    ",{space}{alpha}",
-                    alpha = MaxPrecision::wrap(3, rgba.alpha),
-                    space = space
-                ),
-            )
-        };
-        format!(
-            "rgb{a_prefix}({r},{space}{g},{space}{b}{a})",
-            space = space,
-            a_prefix = a_prefix,
-            r = rgba.r,
-            g = rgba.g,
-            b = rgba.b,
-            a = a,
-        )
+        rgba.to_color_string(format)
     }
 
     /// Convert a `Color` to its cyan, magenta, yellow, and black values. The CMYK
@@ -294,47 +275,15 @@ impl Color {
     /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5, 0)`). If the alpha channel
     /// is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_rgb_float_string(&self, format: Format) -> String {
-        let rgba = RGBA::<f64>::from(self);
-        let space = if format == Format::Spaces { " " } else { "" };
-        let (a_prefix, a) = if self.alpha == 1.0 {
-            ("", "".to_string())
-        } else {
-            (
-                "a",
-                format!(
-                    ",{space}{alpha}",
-                    alpha = MaxPrecision::wrap(3, rgba.alpha),
-                    space = space
-                ),
-            )
-        };
-        format!(
-            "rgb{a_prefix}({r:.3},{space}{g:.3},{space}{b:.3}{a})",
-            space = space,
-            a_prefix = a_prefix,
-            r = rgba.r,
-            g = rgba.g,
-            b = rgba.b,
-            a = a,
-        )
+        let rgba = self.to_rgba_float();
+        rgba.to_color_string(format)
     }
 
     /// Format the color as a RGB-representation string (`#fc0070`). The output will contain 6 hex
     /// digits if the alpha channel is `1.0`, or 8 hex digits otherwise.
     pub fn to_rgb_hex_string(&self, leading_hash: bool) -> String {
         let rgba = self.to_rgba();
-        format!(
-            "{}{:02x}{:02x}{:02x}{}",
-            if leading_hash { "#" } else { "" },
-            rgba.r,
-            rgba.g,
-            rgba.b,
-            if rgba.alpha == 1.0 {
-                "".to_string()
-            } else {
-                format!("{:02x}", (rgba.alpha * 255.).round() as u8)
-            }
-        )
+        rgba.to_hex_string(leading_hash)
     }
 
     /// Convert a `Color` to its red, green, blue and alpha values. All numbers are from the range
@@ -740,58 +689,6 @@ impl From<&HWBA> for Color {
     }
 }
 
-impl From<&RGBA<u8>> for Color {
-    fn from(color: &RGBA<u8>) -> Self {
-        let max_chroma = u8::max(u8::max(color.r, color.g), color.b);
-        let min_chroma = u8::min(u8::min(color.r, color.g), color.b);
-
-        let chroma = max_chroma - min_chroma;
-        let chroma_s = Scalar::from(chroma) / 255.0;
-
-        let r_s = Scalar::from(color.r) / 255.0;
-        let g_s = Scalar::from(color.g) / 255.0;
-        let b_s = Scalar::from(color.b) / 255.0;
-
-        let hue = 60.0
-            * (if chroma == 0 {
-                0.0
-            } else if color.r == max_chroma {
-                mod_positive((g_s - b_s) / chroma_s, 6.0)
-            } else if color.g == max_chroma {
-                (b_s - r_s) / chroma_s + 2.0
-            } else {
-                (r_s - g_s) / chroma_s + 4.0
-            });
-
-        let lightness = (Scalar::from(max_chroma) + Scalar::from(min_chroma)) / (255.0 * 2.0);
-        let saturation = if chroma == 0 {
-            0.0
-        } else {
-            chroma_s / (1.0 - Scalar::abs(2.0 * lightness - 1.0))
-        };
-        Self::from(&HSLA {
-            h: hue,
-            s: saturation,
-            l: lightness,
-            alpha: color.alpha,
-        })
-    }
-}
-
-impl From<&RGBA<f64>> for Color {
-    fn from(color: &RGBA<f64>) -> Self {
-        let r = Scalar::round(clamp(0.0, 255.0, 255.0 * color.r)) as u8;
-        let g = Scalar::round(clamp(0.0, 255.0, 255.0 * color.g)) as u8;
-        let b = Scalar::round(clamp(0.0, 255.0, 255.0 * color.b)) as u8;
-        Self::from(&RGBA::<u8> {
-            r,
-            g,
-            b,
-            alpha: color.alpha,
-        })
-    }
-}
-
 impl From<&LMS> for Color {
     fn from(color: &LMS) -> Self {
         #[rustfmt::skip]
@@ -825,98 +722,6 @@ impl From<&CMYK> for Color {
             b,
             alpha: 1.0,
         })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct RGBA<T> {
-    pub r: T,
-    pub g: T,
-    pub b: T,
-    pub alpha: Scalar,
-}
-
-impl ColorSpace for RGBA<f64> {
-    fn from_color(c: &Color) -> Self {
-        c.to_rgba_float()
-    }
-
-    fn into_color(self) -> Color {
-        Color::from_rgba_float(self.r, self.g, self.b, self.alpha)
-    }
-
-    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
-        Self {
-            r: interpolate(self.r, other.r, fraction),
-            g: interpolate(self.g, other.g, fraction),
-            b: interpolate(self.b, other.b, fraction),
-            alpha: interpolate(self.alpha, other.alpha, fraction),
-        }
-    }
-}
-
-impl From<&Color> for RGBA<f64> {
-    fn from(color: &Color) -> Self {
-        let h_s = color.hue.value() / 60.0;
-        let chr = (1.0 - Scalar::abs(2.0 * color.lightness - 1.0)) * color.saturation;
-        let m = color.lightness - chr / 2.0;
-        let x = chr * (1.0 - Scalar::abs(h_s % 2.0 - 1.0));
-
-        #[allow(clippy::upper_case_acronyms)]
-        struct RGB(Scalar, Scalar, Scalar);
-
-        let col = if h_s < 1.0 {
-            RGB(chr, x, 0.0)
-        } else if (1.0..2.0).contains(&h_s) {
-            RGB(x, chr, 0.0)
-        } else if (2.0..3.0).contains(&h_s) {
-            RGB(0.0, chr, x)
-        } else if (3.0..4.0).contains(&h_s) {
-            RGB(0.0, x, chr)
-        } else if (4.0..5.0).contains(&h_s) {
-            RGB(x, 0.0, chr)
-        } else {
-            RGB(chr, 0.0, x)
-        };
-
-        RGBA {
-            r: col.0 + m,
-            g: col.1 + m,
-            b: col.2 + m,
-            alpha: color.alpha,
-        }
-    }
-}
-
-impl From<&Color> for RGBA<u8> {
-    fn from(color: &Color) -> Self {
-        let c = RGBA::<f64>::from(color);
-        // Tiny rounding errors in `f64` floating point calculations can cause effectively equal
-        // values to round to different integers.  We expect `f64` rounding errors to be less than
-        // the precision of an `f32` in most cases, so we can eliminate many of these rounding
-        // anomalies by first converting the values to `f32` before rounding.
-        let r = f32::round((255.0 * c.r) as f32) as u8;
-        let g = f32::round((255.0 * c.g) as f32) as u8;
-        let b = f32::round((255.0 * c.b) as f32) as u8;
-
-        RGBA {
-            r,
-            g,
-            b,
-            alpha: color.alpha,
-        }
-    }
-}
-
-impl fmt::Display for RGBA<f64> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "rgb({r}, {g}, {b})", r = self.r, g = self.g, b = self.b,)
-    }
-}
-
-impl fmt::Display for RGBA<u8> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "rgb({r}, {g}, {b})", r = self.r, g = self.g, b = self.b,)
     }
 }
 
@@ -1238,29 +1043,6 @@ mod tests {
     }
 
     #[test]
-    fn rgb_roundtrip_conversion() {
-        let roundtrip = |h, s, l| {
-            let color1 = Color::from_hsl(h, s, l);
-            let rgb = color1.to_rgba();
-            let color2 = Color::from_rgb(rgb.r, rgb.g, rgb.b);
-            assert_eq!(color1, color2);
-        };
-
-        roundtrip(0.0, 0.0, 1.0);
-        roundtrip(0.0, 0.0, 0.5);
-        roundtrip(0.0, 0.0, 0.0);
-        roundtrip(60.0, 1.0, 0.375);
-        roundtrip(120.0, 1.0, 0.25);
-        roundtrip(240.0, 1.0, 0.75);
-        roundtrip(49.5, 0.893, 0.497);
-        roundtrip(162.4, 0.779, 0.447);
-
-        for degree in 0..360 {
-            roundtrip(Scalar::from(degree), 0.5, 0.8);
-        }
-    }
-
-    #[test]
     fn to_u32() {
         assert_eq!(0, Color::black().to_u32());
         assert_eq!(0xff0000, Color::red().to_u32());
@@ -1466,20 +1248,8 @@ mod tests {
     #[test]
     fn to_rgb_float_string() {
         assert_eq!(
-            "rgb(0.000, 0.000, 0.000)",
-            Color::black().to_rgb_float_string(Format::Spaces)
-        );
-
-        assert_eq!(
             "rgb(1.000, 1.000, 1.000)",
             Color::white().to_rgb_float_string(Format::Spaces)
-        );
-
-        // some minor rounding errors here, but that is to be expected:
-        let c = Color::from_rgb_float(0.12, 0.45, 0.78);
-        assert_eq!(
-            "rgb(0.122, 0.451, 0.780)",
-            c.to_rgb_float_string(Format::Spaces)
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,11 @@ impl Color {
         Color::from_hsl(0.0, 0.0, lightness)
     }
 
+    /// Change the alpha value of a Color.
+    pub fn with_alpha(&self, alpha: Scalar) -> Color {
+        Self::from_hsla(self.hue.value(), self.saturation, self.lightness, alpha)
+    }
+
     /// Rotate along the "hue" axis.
     pub fn rotate_hue(&self, delta: Scalar) -> Color {
         Self::from_hsla(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod distinct;
 mod helper;
 pub mod hsl;
 pub mod hsv;
+pub mod hwb;
 pub mod lab;
 pub mod lch;
 pub mod matrix;
@@ -24,6 +25,7 @@ use std::{fmt, str::FromStr};
 // Re-export color space types
 pub use hsl::HSLA;
 pub use hsv::HSVA;
+pub use hwb::HWBA;
 pub use lab::Lab;
 pub use lch::LCh;
 pub use rgb::RGBA;
@@ -31,7 +33,7 @@ pub use xyz::XYZ;
 
 use colorspace::ColorSpace;
 pub use helper::Fraction;
-use helper::{clamp, interpolate, interpolate_angle, MaxPrecision};
+use helper::MaxPrecision;
 use matrix::mat3_dot;
 use types::{Hue, Mat3, Scalar};
 
@@ -231,13 +233,7 @@ impl Color {
     /// Format the color as a HWB-representation string (`hwb(123, 50.3%, 80.1%)`).
     pub fn to_hwb_string(&self, format: Format) -> String {
         let hwb = HWBA::from(self);
-        format!(
-            "hwb({h:.0} {w}% {b}%{alpha})",
-            h = hwb.h,
-            w = MaxPrecision::wrap(1, 100.0 * hwb.w),
-            b = MaxPrecision::wrap(1, 100.0 * hwb.b),
-            alpha = format_css_alpha(hwb.alpha, format)
-        )
+        hwb.to_color_string(format)
     }
 
     /// Convert a `Color` to its red, green, blue and alpha values. The RGB values are integers in
@@ -669,26 +665,6 @@ impl FromStr for Color {
     }
 }
 
-impl From<&HWBA> for Color {
-    fn from(color: &HWBA) -> Self {
-        if color.w + color.b >= 1.0 {
-            let gray = color.w / (color.w + color.b);
-            Self::from_rgba_float(gray, gray, gray, color.alpha)
-        } else {
-            let w = clamp(0.0, 1.0, color.w);
-            let b = clamp(0.0, 1.0, color.b);
-            let v = 1.0 - b;
-            let s = 1.0 - (w / v);
-            Self::from(&HSVA {
-                h: color.h,
-                s,
-                v,
-                alpha: color.alpha,
-            })
-        }
-    }
-}
-
 impl From<&LMS> for Color {
     fn from(color: &LMS) -> Self {
         #[rustfmt::skip]
@@ -724,61 +700,6 @@ impl From<&CMYK> for Color {
         })
     }
 }
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct HWBA {
-    pub h: Scalar,
-    pub w: Scalar,
-    pub b: Scalar,
-    pub alpha: Scalar,
-}
-
-impl ColorSpace for HWBA {
-    fn from_color(c: &Color) -> Self {
-        c.to_hwba()
-    }
-
-    fn into_color(self) -> Color {
-        Color::from_hwba(self.h, self.w, self.b, self.alpha)
-    }
-
-    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
-        // make sure that the hue is preserved when mixing with gray colors
-        let self_hue = if (self.w + self.b) >= 1.0 {
-            other.h
-        } else {
-            self.h
-        };
-        let other_hue = if (other.w + other.b) >= 1.0 {
-            self.h
-        } else {
-            other.h
-        };
-
-        Self {
-            h: interpolate_angle(self_hue, other_hue, fraction),
-            w: interpolate(self.w, other.w, fraction),
-            b: interpolate(self.b, other.b, fraction),
-            alpha: interpolate(self.alpha, other.alpha, fraction),
-        }
-    }
-}
-
-impl From<&Color> for HWBA {
-    fn from(color: &Color) -> Self {
-        let HSVA { h, s, v, alpha } = HSVA::from(color);
-
-        let w = (1.0 - s) * v;
-        let b = 1.0 - v;
-        HWBA { h, w, b, alpha }
-    }
-}
-
-// impl fmt::Display for HWBA {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         write!(f, "hwb({h}, {w}, {b})", h = self.h, w = self.w, b = self.b,)
-//     }
-// }
 
 /// A color space whose axes correspond to the responsivity spectra of the long-, medium-, and
 /// short-wavelength cone cells in the human eye. More info
@@ -1051,57 +972,6 @@ mod tests {
     }
 
     #[test]
-    fn hwb_conversion() {
-        let rgbf = Color::from_rgb_float;
-        let rgb128 = 128.0 / 255.0;
-
-        assert_eq!(Color::white(), Color::from_hwb(0.0, 1.0, 0.0));
-        assert_eq!(Color::white(), Color::from_hwb(120.0, 1.0, 0.0));
-        assert_eq!(rgbf(0.5, 0.5, 0.5), Color::from_hwb(0.0, 0.5, 0.5));
-        assert_eq!(Color::gray(), Color::from_hwb(300.0, rgb128, 1.0 - rgb128));
-        assert_eq!(Color::black(), Color::from_hwb(0.0, 0.0, 1.0));
-        assert_eq!(Color::black(), Color::from_hwb(240.0, 0.0, 1.0));
-        assert_eq!(Color::red(), Color::from_hwb(0.0, 0.0, 0.0));
-        assert_eq!(
-            Color::from_hsl(60.0, 1.0, 0.375),
-            Color::from_hwb(60.0, 0.0, 0.25)
-        ); //yellow-green
-        assert_eq!(Color::green(), Color::from_hwb(120.0, 0.0, 1.0 - rgb128));
-        assert_eq!(
-            Color::from_hsl(240.0, 1.0, 0.75),
-            Color::from_hwb(240.0, 0.5, 0.0)
-        ); // blue-ish
-
-        assert_eq!(
-            Color::from_hsl(49.5, 0.8922, 0.4973),
-            Color::from_hwb(49.5, 0.0536, 0.0590)
-        ); //yellow
-        assert_eq!(
-            Color::from_hsl(162.4, 0.7794, 0.4468),
-            Color::from_hwb(162.4, 0.09856, 0.20496)
-        ); // cyan 2
-
-        assert_eq!(
-            Color::from_rgba_float(0.75, 0.0, 0.75, 0.4),
-            Color::from_hwba(300.0, 0.0, 0.25, 0.4)
-        )
-    }
-
-    #[test]
-    fn hwb_roundtrip_conversion() {
-        let roundtrip = |h, s, l| {
-            let color1 = Color::from_hsl(h, s, l);
-            let hwb1 = color1.to_hwba();
-            let color2 = Color::from_hwb(hwb1.h, hwb1.w, hwb1.b);
-            assert_eq!(&color1, &color2);
-        };
-
-        for hue in 0..360 {
-            roundtrip(Scalar::from(hue), 0.2, 0.8);
-        }
-    }
-
-    #[test]
     fn lms_conversion() {
         let roundtrip = |h, s, l| {
             let color1 = Color::from_hsl(h, s, l);
@@ -1200,24 +1070,12 @@ mod tests {
     #[test]
     fn to_hwb_string() {
         let c = Color::from_hwb(91.0, 0.541, 0.383);
-        // modern CSS functional syntax
+        // modern CSS functional syntax, no alpha value
         assert_eq!("hwb(91 54.1% 38.3%)", c.to_hwb_string(Format::Spaces));
-        // spaces are required, so NoSpaces has no effect without akpha
-        assert_eq!("hwb(91 54.1% 38.3%)", c.to_hwb_string(Format::NoSpaces));
 
-        let c1 = Color::from_hwb(91.3, 0.541, 0.383172);
-        // hue is rounded to integer, w and b are rounded to 1 decimal
-        assert_eq!("hwb(91 54.1% 38.3%)", c1.to_hwb_string(Format::Spaces));
-
-        let c2 = Color::from_hwb(90.0, 0.5, 0.25);
-        // trailing decimal zeros are not included
-        assert_eq!("hwb(90 50% 25%)", c2.to_hwb_string(Format::Spaces));
-
-        let c2a = Color::from_hwba(90.0, 0.5, 0.25, 0.8);
+        let c1 = Color::from_hwba(90.0, 0.5, 0.25, 0.8);
         // non-unit alpha is serialized as a number
-        assert_eq!("hwb(90 50% 25% / 0.8)", c2a.to_hwb_string(Format::Spaces));
-        // spaces are optional around alpha separator, so NoSpaces applies
-        assert_eq!("hwb(90 50% 25%/0.8)", c2a.to_hwb_string(Format::NoSpaces));
+        assert_eq!("hwb(90 50% 25% / 0.8)", c1.to_hwb_string(Format::Spaces));
     }
 
     // Test alternative alpha formats once for shared function.  Each format that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod convert;
 pub mod delta_e;
 pub mod distinct;
 mod helper;
+pub mod hsv;
 pub mod matrix;
 pub mod named;
 pub mod parser;
@@ -11,6 +12,9 @@ pub mod random;
 mod types;
 
 use std::{fmt, str::FromStr};
+
+// Re-export color space types
+pub use hsv::HSVA;
 
 use colorspace::ColorSpace;
 use convert::{gam_srgb, lin_srgb};
@@ -232,28 +236,7 @@ impl Color {
     /// alpha channel is `1.0`, the simplified `hsv()` format will be used instead.
     pub fn to_hsv_string(&self, format: Format) -> String {
         let hsv = HSVA::from(self);
-        let space = if format == Format::Spaces { " " } else { "" };
-        let (a_prefix, a) = if hsv.alpha == 1.0 {
-            ("", "".to_string())
-        } else {
-            (
-                "a",
-                format!(
-                    ",{space}{alpha}",
-                    alpha = MaxPrecision::wrap(3, hsv.alpha),
-                    space = space
-                ),
-            )
-        };
-        format!(
-            "hsv{a_prefix}({h:.0},{space}{s:.1}%,{space}{v:.1}%{a})",
-            space = space,
-            a_prefix = a_prefix,
-            h = hsv.h,
-            s = 100.0 * hsv.s,
-            v = 100.0 * hsv.v,
-            a = a,
-        )
+        hsv.to_color_string(format)
     }
 
     /// Convert a `Color` to its hue, whiteness, blackness, and alpha values. The hue is given in
@@ -800,24 +783,6 @@ impl From<&HSLA> for Color {
     }
 }
 
-impl From<&HSVA> for Color {
-    fn from(color: &HSVA) -> Self {
-        let lightness = color.v * (1.0 - color.s / 2.0);
-        let saturation = if lightness > 0.0 && lightness < 1.0 {
-            (color.v - lightness) / lightness.min(1.0 - lightness)
-        } else {
-            0.0
-        };
-
-        Color {
-            hue: Hue::from(color.h),
-            saturation: clamp(0.0, 1.0, saturation),
-            lightness: clamp(0.0, 1.0, lightness),
-            alpha: clamp(0.0, 1.0, color.alpha),
-        }
-    }
-}
-
 impl From<&HWBA> for Color {
     fn from(color: &HWBA) -> Self {
         if color.w + color.b >= 1.0 {
@@ -1127,63 +1092,6 @@ impl From<&Color> for HSLA {
 impl fmt::Display for HSLA {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "hsl({h}, {s}, {l})", h = self.h, s = self.s, l = self.l,)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct HSVA {
-    pub h: Scalar,
-    pub s: Scalar,
-    pub v: Scalar,
-    pub alpha: Scalar,
-}
-
-impl ColorSpace for HSVA {
-    fn from_color(c: &Color) -> Self {
-        c.to_hsva()
-    }
-
-    fn into_color(self) -> Color {
-        Color::from_hsva(self.h, self.s, self.v, self.alpha)
-    }
-
-    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
-        // make sure that the hue is preserved when mixing with gray colors
-        let self_hue = if self.s < 0.0001 { other.h } else { self.h };
-        let other_hue = if other.s < 0.0001 { self.h } else { other.h };
-
-        Self {
-            h: interpolate_angle(self_hue, other_hue, fraction),
-            s: interpolate(self.s, other.s, fraction),
-            v: interpolate(self.v, other.v, fraction),
-            alpha: interpolate(self.alpha, other.alpha, fraction),
-        }
-    }
-}
-
-impl From<&Color> for HSVA {
-    fn from(color: &Color) -> Self {
-        let lightness = color.lightness;
-
-        let value = lightness + color.saturation * lightness.min(1.0 - lightness);
-        let saturation = if value > 0.0 {
-            2.0 * (1.0 - lightness / value)
-        } else {
-            0.0
-        };
-
-        HSVA {
-            h: color.hue.value(),
-            s: saturation,
-            v: value,
-            alpha: color.alpha,
-        }
-    }
-}
-
-impl fmt::Display for HSVA {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "hsv({h}, {s}, {v})", h = self.h, s = self.s, v = self.v)
     }
 }
 
@@ -1688,25 +1596,6 @@ mod tests {
         assert_eq!(0xff0000, Color::red().to_u32());
         assert_eq!(0xffffff, Color::white().to_u32());
         assert_eq!(0xf4230f, Color::from_rgb(0xf4, 0x23, 0x0f).to_u32());
-    }
-
-    #[test]
-    fn hsva_conversion() {
-        assert_eq!(
-            Color::from_hsla(0.0, 1.0, 0.5, 0.5),
-            Color::from_hsva(0.0, 1.0, 1.0, 0.5)
-        );
-
-        let roundtrip = |h, s, l| {
-            let color1 = Color::from_hsl(h, s, l);
-            let hsva1 = color1.to_hsva();
-            let color2 = Color::from_hsva(hsva1.h, hsva1.s, hsva1.v, hsva1.alpha);
-            assert_almost_equal(&color1, &color2);
-        };
-
-        for hue in 0..360 {
-            roundtrip(Scalar::from(hue), 0.2, 0.8);
-        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,24 @@
 pub mod ansi;
-pub mod cmyk;
-pub mod color_scale;
+mod cmyk;
+mod color_scale;
 pub mod colorspace;
 pub mod convert;
 pub mod delta_e;
 pub mod distinct;
 mod helper;
-pub mod hsl;
-pub mod hsv;
-pub mod hwb;
-pub mod lab;
-pub mod lch;
-pub mod lms;
+mod hsl;
+mod hsv;
+mod hwb;
+mod lab;
+mod lch;
+mod lms;
 pub mod matrix;
 pub mod named;
 pub mod parser;
 pub mod random;
-pub mod rgb;
+mod rgb;
 mod types;
-pub mod xyz;
+mod xyz;
 
 #[cfg(test)]
 mod test_helper;

--- a/src/lms.rs
+++ b/src/lms.rs
@@ -1,0 +1,92 @@
+use std::fmt;
+
+use crate::{
+    matrix::mat3_dot,
+    types::{Mat3, Scalar},
+    xyz::XYZ,
+    Color,
+};
+
+/// A color space whose axes correspond to the responsivity spectra of the long-, medium-, and
+/// short-wavelength cone cells in the human eye. More info
+/// [here](https://en.wikipedia.org/wiki/LMS_color_space).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LMS {
+    pub l: Scalar,
+    pub m: Scalar,
+    pub s: Scalar,
+    pub alpha: Scalar,
+}
+
+impl From<&Color> for LMS {
+    fn from(color: &Color) -> Self {
+        #[rustfmt::skip]
+        const M: Mat3 = [
+             0.38971, 0.68898, -0.07868,
+            -0.22981, 1.18340,  0.04641,
+             0.00000, 0.00000,  1.00000,
+        ];
+
+        let XYZ { x, y, z, alpha } = XYZ::from(color);
+        let [l, m, s] = mat3_dot(M, [x, y, z]);
+
+        LMS { l, m, s, alpha }
+    }
+}
+
+impl From<&LMS> for Color {
+    fn from(color: &LMS) -> Self {
+        #[rustfmt::skip]
+        const M: Mat3 = [
+            1.91020, -1.112_120, 0.201_908,
+            0.37095,  0.629_054, 0.000_000,
+            0.00000,  0.000_000, 1.000_000
+        ];
+
+        let [x, y, z] = mat3_dot(M, [color.l, color.m, color.s]);
+        Self::from(&XYZ {
+            x,
+            y,
+            z,
+            alpha: color.alpha,
+        })
+    }
+}
+
+impl fmt::Display for LMS {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "LMS({l}, {m}, {s})", l = self.l, m = self.m, s = self.s,)
+    }
+}
+
+impl LMS {
+    #[inline]
+    pub fn new(l: Scalar, m: Scalar, s: Scalar) -> Self {
+        Self::with_alpha(l, m, s, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(l: Scalar, m: Scalar, s: Scalar, alpha: Scalar) -> Self {
+        LMS { l, m, s, alpha }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helper::assert_almost_equal;
+
+    #[test]
+    fn lms_conversion() {
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let lms1 = color1.to_lms();
+            let color2 = Color::from_lms(lms1.l, lms1.m, lms1.s, 1.0);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -147,11 +147,7 @@ where
 }
 
 fn parse_css_color_fn(input: &str) -> IResult<&str, Color> {
-    alt((
-        all_consuming(parse_cie_xyz65_color_space),
-        all_consuming(parse_cie_lab65_color_space),
-        all_consuming(parse_cie_lch65_color_space),
-    ))(input.trim())
+    all_consuming(parse_cie_xyz65_color_space)(input.trim())
 }
 
 // CSS Color 4 defines separate D65-adapted (`xyz-d65`, or just `xyz`) and D5-adapted (`xyz-d50`)
@@ -171,49 +167,6 @@ fn parse_cie_xyz65_color_space(input: &str) -> IResult<&str, Color> {
 
     let xyz_name = alt((tag_no_case("xyz-d65"), tag_no_case("xyz")));
     css_color_function(xyz_name, xyz_components)(input)
-}
-
-// The "culori" library uses custom `--lab-d65` and `--lch-d65` color space names, consistent with
-// the CSS Color 5 draft.  Percentage values are not supported here because the CSS `color()`
-// function defines that 100% = 1.0 for all component values, so percentages would produce
-// inconsistent and confusing values.  Where there is no ambiguity, however, we try to be lenient
-// for broader compatibility.
-
-fn parse_cie_lab65_color_space(input: &str) -> IResult<&str, Color> {
-    fn lab_components(input: &str) -> IResult<&str, Color> {
-        // Don't allow percentages because 100% = 1.0 for color space components.
-        let (input, l) = double(input)?;
-        let (input, _) = space1(input)?;
-        let (input, a) = double(input)?;
-        let (input, _) = space1(input)?;
-        let (input, b) = double(input)?;
-
-        let c = Color::from_lab(l, a, b, 1.0);
-        Ok((input, c))
-    }
-
-    // Custom color space "<dashed-ident>" prefix is optional.
-    let lab_name = preceded(opt(tag("--")), tag_no_case("lab-d65"));
-    css_color_function(lab_name, lab_components)(input)
-}
-
-fn parse_cie_lch65_color_space(input: &str) -> IResult<&str, Color> {
-    fn lch_components(input: &str) -> IResult<&str, Color> {
-        // Don't allow percentages because 100% = 1.0 for color space components.
-        let (input, l) = double(input)?;
-        let (input, _) = space1(input)?;
-        let (input, c) = double(input)?;
-        let (input, _) = space1(input)?;
-        // Optional angle units are allowed because they are not ambiguous.
-        let (input, h) = hue_angle(input)?;
-
-        let c = Color::from_lch(l, c, h, 1.0);
-        Ok((input, c))
-    }
-
-    // Custom color space "<dashed-ident>" prefix is optional.
-    let lch_name = preceded(opt(tag("--")), tag_no_case("lch-d65"));
-    css_color_function(lch_name, lch_components)(input)
 }
 
 pub fn parse_color(input: &str) -> Option<Color> {
@@ -499,147 +452,27 @@ fn parse_xyz50_color_space_syntax() {
 }
 
 #[test]
-fn parse_lab65_color_space_syntax() {
-    assert_eq!(
-        Some(Color::from_lab(12.43, -35.5, 43.4, 1.0)),
-        parse_color("color(lab-d65 12.43 -35.5 43.4)")
-    );
+fn parse_color_lab_d65_string() {
     assert_eq!(
         Some(Color::from_lab(15.0, 23.0, -43.0, 1.0)),
         parse_color("color(lab-d65 15 23 -43)")
     );
-
-    // `--lab-d65` is equivalent to `lab-d65`
-    assert_eq!(
-        Some(Color::from_lab(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(--lab-d65 15 25 90)")
-    );
-
-    // color space name is case-insensitive
-    assert_eq!(
-        Some(Color::from_lab(50.0, 10.0, 20.0, 1.0)),
-        parse_color("color(Lab-D65 50 10 20)")
-    );
-
-    // alpha value is supported as a number or percentage
     assert_eq!(
         Some(Color::from_lab(15.0, -23.0, 43.0, 0.5)),
         parse_color("color(lab-d65 15 -23 43 / 0.5)")
     );
-    assert_eq!(
-        Some(Color::from_lab(15.0, -35.5, -43.4, 0.4)),
-        parse_color("color(lab-d65 15 -35.5 -43.4 / 40%)")
-    );
-
-    // extra spaces are allowed
-    assert_eq!(
-        Some(Color::from_lab(15.0, 23.0, -43.0, 1.0)),
-        parse_color("color(lab-d65     15    23      -43)")
-    );
-    assert_eq!(
-        Some(Color::from_lab(15.0, 23.0, -43.0, 1.0)),
-        parse_color("color(   lab-d65   15 23 -43)")
-    );
-    assert_eq!(
-        Some(Color::from_lab(15.0, 23.0, -43.0, 0.6)),
-        parse_color("color(lab-d65   15     23    -43/     60%)")
-    );
-
-    // percentage values are not allowed
-    assert_eq!(None, parse_color("color(lab-d65 15% 25 90)"));
-    assert_eq!(None, parse_color("color(lab-d65 15% 100% 0%)"));
-    assert_eq!(None, parse_color("color(lab-d65 15% 0% -100%)"));
-    assert_eq!(None, parse_color("color(lab-d65 15% 80% 80.0)"));
-
-    // not enough parameters
-    assert_eq!(None, parse_color("color(lab-d65 15 25)"));
-    // too many parameters
-    assert_eq!(None, parse_color("color(lab-d65 15 25 90 120)"));
-    // comma separators not allowed
-    assert_eq!(None, parse_color("color(lab-d65 15, 25, 90)"));
 }
 
 #[test]
-fn parse_lch65_color_space_syntax() {
-    assert_eq!(
-        Some(Color::from_lch(12.43, 35.5, 43.4, 1.0)),
-        parse_color("color(lch-d65 12.43 35.5 43.4)")
-    );
+fn parse_color_lch_d65_string() {
     assert_eq!(
         Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
         parse_color("color(lch-d65 15 25 90)")
     );
-
-    // hue angle can be negative
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, -45.0, 1.0)),
-        parse_color("color(lch-d65 15 25 -45)")
-    );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 315.0, 1.0)),
-        parse_color("color(lch-d65 15 25 -45)")
-    );
-
-    // hue angle can include a unit identifier
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(lch-d65 15 25 90deg)")
-    );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(lch-d65 15 25 100grad)")
-    );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(lch-d65 15 25 0.25turn)")
-    );
-
-    // `--lch-d65` is equivalent to `lch-d65`
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(--lch-d65 15 25 90)")
-    );
-
-    // color space name is case-insensitive
-    assert_eq!(
-        Some(Color::from_lch(50.0, 20.0, 180.0, 1.0)),
-        parse_color("color(LCh-D65 50 20 180)")
-    );
-
-    // alpha value is supported as a number or percentage
     assert_eq!(
         Some(Color::from_lch(15.0, 23.0, 43.0, 0.5)),
         parse_color("color(lch-d65 15 23 43 / 0.5)")
     );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 23.0, 43.0, 0.75)),
-        parse_color("color(lch-d65 15 23 43 / 75%)")
-    );
-
-    // extra spaces are allowed
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(lch-d65     15    25      90)")
-    );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 1.0)),
-        parse_color("color(   lch-d65   15 25 90)")
-    );
-    assert_eq!(
-        Some(Color::from_lch(15.0, 25.0, 90.0, 0.6)),
-        parse_color("color(lch-d65   15     25    90      /0.6)")
-    );
-
-    // percentage values are not allowed
-    assert_eq!(None, parse_color("color(lch-d65 15% 25 90)"));
-    assert_eq!(None, parse_color("color(lch-d65 15% 100% 90)"));
-
-    // not enough parameters
-    assert_eq!(None, parse_color("color(lch-d65 15 25)"));
-    // too many parameters
-    assert_eq!(None, parse_color("color(lch-d65 15 25 90 120)"));
-    // comma separators not allowed
-    assert_eq!(None, parse_color("color(lch-d65 15, 25, 90)"));
 }
 
 #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
-use nom::bytes::complete::*;
-use nom::character::complete::*;
-use nom::combinator::*;
+use nom::bytes::complete::{tag, tag_no_case};
+use nom::character::complete::{alpha1, char, space0, space1};
+use nom::combinator::{all_consuming, opt, verify};
 use nom::number::complete::double;
 use nom::sequence::{delimited, preceded};
 use nom::Parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,9 @@ use nom::number::complete::double;
 use nom::Err;
 use nom::IResult;
 
-use crate::{convert::gam_srgb, hsl::HSLA, named::NAMED_COLORS, rgb::parse_rgb_color, Color};
+use crate::{
+    convert::gam_srgb, hsl::parse_hsl_color, named::NAMED_COLORS, rgb::parse_rgb_color, Color,
+};
 
 fn comma_separator(input: &str) -> IResult<&str, &str> {
     let (input, _) = space0(input)?;
@@ -423,7 +425,7 @@ fn parse_css_device_cmyk(input: &str) -> IResult<&str, Color> {
 pub fn parse_color(input: &str) -> Option<Color> {
     alt((
         parse_rgb_color,
-        all_consuming(HSLA::parse),
+        parse_hsl_color,
         all_consuming(parse_css_color_fn),
         all_consuming(parse_css_hsv),
         all_consuming(parse_hsv),

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -234,6 +234,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn rgb_to_hsl_conversion() {
+        assert_eq!(Color::white(), Color::from_rgb_float(1.0, 1.0, 1.0));
+        assert_eq!(Color::gray(), Color::from_rgb_float(0.5, 0.5, 0.5));
+        assert_eq!(Color::black(), Color::from_rgb_float(0.0, 0.0, 0.0));
+        assert_eq!(Color::red(), Color::from_rgb_float(1.0, 0.0, 0.0));
+        assert_eq!(
+            Color::from_hsl(60.0, 1.0, 0.375),
+            Color::from_rgb_float(0.75, 0.75, 0.0)
+        ); //yellow-green
+        assert_eq!(Color::green(), Color::from_rgb_float(0.0, 0.5, 0.0));
+        assert_eq!(
+            Color::from_hsl(240.0, 1.0, 0.75),
+            Color::from_rgb_float(0.5, 0.5, 1.0)
+        ); // blue-ish
+        assert_eq!(
+            Color::from_hsl(49.5, 0.893, 0.497),
+            Color::from_rgb_float(0.941, 0.785, 0.053)
+        ); // yellow
+        assert_eq!(
+            Color::from_hsl(162.4, 0.779, 0.447),
+            Color::from_rgb_float(0.099, 0.795, 0.591)
+        ); // cyan 2
+    }
+
+    #[test]
     fn rgb_u8_roundtrip_conversion() {
         let roundtrip = |h, s, l| {
             let color1 = Color::from_hsl(h, s, l);

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -170,6 +170,12 @@ impl<T> RGBA<T> {
 }
 
 impl RGBA<u8> {
+    /// Return the color as an integer in RGB representation (`0xRRGGBB`)
+    #[inline]
+    pub fn to_u32(&self) -> u32 {
+        u32::from(self.r).wrapping_shl(16) + u32::from(self.g).wrapping_shl(8) + u32::from(self.b)
+    }
+
     /// Format the color as a RGB-representation string (`rgba(255, 127, 0, 0.5)`). If the alpha
     /// channel is `1.0`, the simplified `rgb()` format will be used instead.
     pub fn to_color_string(&self, format: Format) -> String {
@@ -463,6 +469,17 @@ mod tests {
         for degree in 0..360 {
             roundtrip(Scalar::from(degree), 0.5, 0.8);
         }
+    }
+
+    #[test]
+    fn rgb_to_u32_conversion() {
+        assert_eq!(0, rgb(0, 0, 0).to_u32());
+        assert_eq!(0xff0000, rgb(255, 0, 0).to_u32());
+        assert_eq!(0xffff00, Color::yellow().to_u32());
+        assert_eq!(0xff00ff, Color::fuchsia().to_u32());
+        assert_eq!(0x00ffff, Color::aqua().to_u32());
+        assert_eq!(0xffffff, rgb(255, 255, 255).to_u32());
+        assert_eq!(0xf4230f, rgb(0xf4, 0x23, 0x0f).to_u32());
     }
 
     #[test]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,0 +1,301 @@
+use std::fmt;
+
+use crate::{
+    colorspace::ColorSpace,
+    helper::{clamp, interpolate, mod_positive, MaxPrecision},
+    hsl::HSLA,
+    types::Scalar,
+    Color, Format, Fraction,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RGBA<T> {
+    pub r: T,
+    pub g: T,
+    pub b: T,
+    pub alpha: Scalar,
+}
+
+impl ColorSpace for RGBA<f64> {
+    fn from_color(c: &Color) -> Self {
+        c.to_rgba_float()
+    }
+
+    fn into_color(self) -> Color {
+        Color::from_rgba_float(self.r, self.g, self.b, self.alpha)
+    }
+
+    fn mix(&self, other: &Self, fraction: Fraction) -> Self {
+        Self {
+            r: interpolate(self.r, other.r, fraction),
+            g: interpolate(self.g, other.g, fraction),
+            b: interpolate(self.b, other.b, fraction),
+            alpha: interpolate(self.alpha, other.alpha, fraction),
+        }
+    }
+}
+
+impl From<&Color> for RGBA<f64> {
+    fn from(color: &Color) -> Self {
+        let h_s = color.hue.value() / 60.0;
+        let chr = (1.0 - Scalar::abs(2.0 * color.lightness - 1.0)) * color.saturation;
+        let m = color.lightness - chr / 2.0;
+        let x = chr * (1.0 - Scalar::abs(h_s % 2.0 - 1.0));
+
+        #[allow(clippy::upper_case_acronyms)]
+        struct RGB(Scalar, Scalar, Scalar);
+
+        let col = if h_s < 1.0 {
+            RGB(chr, x, 0.0)
+        } else if (1.0..2.0).contains(&h_s) {
+            RGB(x, chr, 0.0)
+        } else if (2.0..3.0).contains(&h_s) {
+            RGB(0.0, chr, x)
+        } else if (3.0..4.0).contains(&h_s) {
+            RGB(0.0, x, chr)
+        } else if (4.0..5.0).contains(&h_s) {
+            RGB(x, 0.0, chr)
+        } else {
+            RGB(chr, 0.0, x)
+        };
+
+        RGBA {
+            r: col.0 + m,
+            g: col.1 + m,
+            b: col.2 + m,
+            alpha: color.alpha,
+        }
+    }
+}
+
+impl From<&Color> for RGBA<u8> {
+    fn from(color: &Color) -> Self {
+        let c = RGBA::<f64>::from(color);
+        // Tiny rounding errors in `f64` floating point calculations can cause effectively equal
+        // values to round to different integers.  We expect `f64` rounding errors to be less than
+        // the precision of an `f32` in most cases, so we can eliminate many of these rounding
+        // anomalies by first converting the values to `f32` before rounding.
+        let r = f32::round((255.0 * c.r) as f32) as u8;
+        let g = f32::round((255.0 * c.g) as f32) as u8;
+        let b = f32::round((255.0 * c.b) as f32) as u8;
+
+        RGBA {
+            r,
+            g,
+            b,
+            alpha: color.alpha,
+        }
+    }
+}
+
+impl From<&RGBA<u8>> for Color {
+    fn from(color: &RGBA<u8>) -> Self {
+        let max_chroma = u8::max(u8::max(color.r, color.g), color.b);
+        let min_chroma = u8::min(u8::min(color.r, color.g), color.b);
+
+        let chroma = max_chroma - min_chroma;
+        let chroma_s = Scalar::from(chroma) / 255.0;
+
+        let r_s = Scalar::from(color.r) / 255.0;
+        let g_s = Scalar::from(color.g) / 255.0;
+        let b_s = Scalar::from(color.b) / 255.0;
+
+        let hue = 60.0
+            * (if chroma == 0 {
+                0.0
+            } else if color.r == max_chroma {
+                mod_positive((g_s - b_s) / chroma_s, 6.0)
+            } else if color.g == max_chroma {
+                (b_s - r_s) / chroma_s + 2.0
+            } else {
+                (r_s - g_s) / chroma_s + 4.0
+            });
+
+        let lightness = (Scalar::from(max_chroma) + Scalar::from(min_chroma)) / (255.0 * 2.0);
+        let saturation = if chroma == 0 {
+            0.0
+        } else {
+            chroma_s / (1.0 - Scalar::abs(2.0 * lightness - 1.0))
+        };
+        Self::from(&HSLA::with_alpha(hue, saturation, lightness, color.alpha))
+    }
+}
+
+impl From<&RGBA<f64>> for Color {
+    fn from(color: &RGBA<f64>) -> Self {
+        let r = Scalar::round(clamp(0.0, 255.0, 255.0 * color.r)) as u8;
+        let g = Scalar::round(clamp(0.0, 255.0, 255.0 * color.g)) as u8;
+        let b = Scalar::round(clamp(0.0, 255.0, 255.0 * color.b)) as u8;
+        Self::from(&RGBA::with_alpha(r, g, b, color.alpha))
+    }
+}
+
+impl fmt::Display for RGBA<f64> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "rgb({r}, {g}, {b})", r = self.r, g = self.g, b = self.b,)
+    }
+}
+
+impl fmt::Display for RGBA<u8> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "rgb({r}, {g}, {b})", r = self.r, g = self.g, b = self.b,)
+    }
+}
+
+impl<T> RGBA<T> {
+    #[inline]
+    pub fn new(r: T, g: T, b: T) -> Self {
+        Self::with_alpha(r, g, b, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(r: T, g: T, b: T, alpha: Scalar) -> Self {
+        RGBA { r, g, b, alpha }
+    }
+}
+
+impl RGBA<u8> {
+    /// Format the color as a RGB-representation string (`rgba(255, 127, 0, 0.5)`). If the alpha
+    /// channel is `1.0`, the simplified `rgb()` format will be used instead.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                ),
+            )
+        };
+        format!(
+            "rgb{a_prefix}({r},{space}{g},{space}{b}{a})",
+            space = space,
+            a_prefix = a_prefix,
+            r = self.r,
+            g = self.g,
+            b = self.b,
+            a = a,
+        )
+    }
+
+    /// Format the color as a RGB-representation string (`#fc0070`). The output will contain 6 hex
+    /// digits if the alpha channel is `1.0`, or 8 hex digits otherwise.
+    pub fn to_hex_string(&self, leading_hash: bool) -> String {
+        format!(
+            "{}{:02x}{:02x}{:02x}{}",
+            if leading_hash { "#" } else { "" },
+            self.r,
+            self.g,
+            self.b,
+            if self.alpha == 1.0 {
+                "".to_string()
+            } else {
+                format!("{:02x}", (self.alpha * 255.).round() as u8)
+            }
+        )
+    }
+}
+
+impl RGBA<f64> {
+    /// Format the color as a floating point RGB-representation string (`rgb(1.0, 0.5, 0)`). If the
+    /// alpha channel is `1.0`, the simplified `rgb()` format will be used instead.
+    pub fn to_color_string(&self, format: Format) -> String {
+        let space = if format == Format::Spaces { " " } else { "" };
+        let (a_prefix, a) = if self.alpha == 1.0 {
+            ("", "".to_string())
+        } else {
+            (
+                "a",
+                format!(
+                    ",{space}{alpha}",
+                    alpha = MaxPrecision::wrap(3, self.alpha),
+                    space = space
+                ),
+            )
+        };
+        format!(
+            "rgb{a_prefix}({r:.3},{space}{g:.3},{space}{b:.3}{a})",
+            space = space,
+            a_prefix = a_prefix,
+            r = self.r,
+            g = self.g,
+            b = self.b,
+            a = a,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rgb_u8_roundtrip_conversion() {
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let rgb = color1.to_rgba();
+            let color2 = Color::from_rgb(rgb.r, rgb.g, rgb.b);
+            assert_eq!(color1, color2);
+        };
+
+        roundtrip(0.0, 0.0, 1.0);
+        roundtrip(0.0, 0.0, 0.5);
+        roundtrip(0.0, 0.0, 0.0);
+        roundtrip(60.0, 1.0, 0.375);
+        roundtrip(120.0, 1.0, 0.25);
+        roundtrip(240.0, 1.0, 0.75);
+        roundtrip(49.5, 0.893, 0.497);
+        roundtrip(162.4, 0.779, 0.447);
+
+        for degree in 0..360 {
+            roundtrip(Scalar::from(degree), 0.5, 0.8);
+        }
+    }
+
+    #[test]
+    fn to_color_string_u8() {
+        let c = RGBA::new(255, 127, 4);
+        assert_eq!("rgb(255, 127, 4)", c.to_color_string(Format::Spaces));
+        assert_eq!("rgb(255,127,4)", c.to_color_string(Format::NoSpaces));
+    }
+
+    #[test]
+    fn to_color_string_f64() {
+        let cb = Color::black().to_rgba_float();
+        assert_eq!(
+            "rgb(0.000, 0.000, 0.000)",
+            cb.to_color_string(Format::Spaces)
+        );
+        assert_eq!(
+            "rgb(0.000,0.000,0.000)",
+            cb.to_color_string(Format::NoSpaces)
+        );
+
+        let cw = Color::white().to_rgba_float();
+        assert_eq!(
+            "rgb(1.000, 1.000, 1.000)",
+            cw.to_color_string(Format::Spaces)
+        );
+        assert_eq!(
+            "rgb(1.000,1.000,1.000)",
+            cw.to_color_string(Format::NoSpaces)
+        );
+
+        let c = RGBA::new(0.12, 0.45, 0.78);
+        assert_eq!(
+            "rgb(0.120, 0.450, 0.780)",
+            c.to_color_string(Format::Spaces)
+        );
+    }
+
+    #[test]
+    fn to_rgb_hex_string() {
+        let c = RGBA::new(255, 127, 4);
+        assert_eq!("ff7f04", c.to_hex_string(false));
+        assert_eq!("#ff7f04", c.to_hex_string(true));
+    }
+}

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -1,0 +1,10 @@
+use crate::Color;
+
+pub fn assert_almost_equal(c1: &Color, c2: &Color) {
+    let c1 = c1.to_rgba();
+    let c2 = c2.to_rgba();
+
+    assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
+    assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
+    assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,13 +33,6 @@ impl Hue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::assert_relative_eq;
-
-    #[test]
-    fn test_mod_positive() {
-        assert_relative_eq!(0.5, mod_positive(2.9, 2.4));
-        assert_relative_eq!(1.7, mod_positive(-0.3, 2.0));
-    }
 
     #[test]
     fn test_hue_clipping() {

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,8 +1,14 @@
 use std::fmt;
 
+use nom::{
+    branch::alt, bytes::complete::tag_no_case, character::complete::space1,
+    combinator::all_consuming, IResult,
+};
+
 use crate::{
     convert::{gam_srgb, lin_srgb},
     matrix::mat3_dot,
+    parser::{css_color_function, number_or_percentage},
     types::{Mat3, Scalar},
     Color, RGBA,
 };
@@ -70,6 +76,29 @@ impl XYZ {
     }
 }
 
+pub(crate) fn parse_xyz_color(input: &str) -> IResult<&str, Color> {
+    alt((all_consuming(parse_xyz_d65_color_space),))(input.trim())
+}
+
+// CSS Color 4 defines separate D65-adapted (`xyz-d65`, or just `xyz`) and D5-adapted (`xyz-d50`)
+// color spaces.  Currently, `pastel` does not support chromatic adaptation, and only uses the D65
+// illuminant, so we only support the `xyz-d65` color space here.
+fn parse_xyz_d65_color_space(input: &str) -> IResult<&str, Color> {
+    fn xyz_components(input: &str) -> IResult<&str, Color> {
+        let (input, x) = number_or_percentage(input, 1.0)?;
+        let (input, _) = space1(input)?;
+        let (input, y) = number_or_percentage(input, 1.0)?;
+        let (input, _) = space1(input)?;
+        let (input, z) = number_or_percentage(input, 1.0)?;
+
+        let c = Color::from_xyz(x, y, z, 1.0);
+        Ok((input, c))
+    }
+
+    let xyz_name = alt((tag_no_case("xyz-d65"), tag_no_case("xyz")));
+    css_color_function(xyz_name, xyz_components)(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,5 +123,91 @@ mod tests {
         for hue in 0..360 {
             roundtrip(Scalar::from(hue), 0.2, 0.8);
         }
+    }
+
+    fn parse_color(input: &str) -> Option<Color> {
+        parse_xyz_color(input).ok().map(|(_, c)| c)
+    }
+
+    #[test]
+    fn parse_xyz65_color_space_syntax() {
+        fn xyz(x: f64, y: f64, z: f64) -> Color {
+            Color::from_xyz(x, y, z, 1.0)
+        }
+
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz-d65 0.3 0.5 0.7)")
+        );
+
+        assert_eq!(
+            Some(xyz(0.950_470, 1.0, 1.088_830)),
+            parse_color("color(xyz-d65 0.950470 1 1.088830)")
+        );
+
+        assert_eq!(
+            Some(xyz(-0.004, 1.007, -1.2222)),
+            parse_color("color(xyz-d65 -0.004 1.007000 -1.2222)")
+        );
+
+        // percentages are allowed
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz-d65 30% 50% 70%)")
+        );
+        // numbers and percentages can be mixed
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz-d65 0.3 50% 0.7)")
+        );
+
+        // `xyz` is equivalent to `xyz-d65`
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz 0.3 0.5 0.7)")
+        );
+
+        // extra spaces are allowed
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz-d65  0.3   0.5    0.7)")
+        );
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(   xyz-d65   0.3 0.5 0.7)")
+        );
+
+        // color space name is case-insensitive
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(XYZ 0.3 0.5 0.7)")
+        );
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(Xyz 0.3 0.5 0.7)")
+        );
+        assert_eq!(
+            Some(xyz(0.3, 0.5, 0.7)),
+            parse_color("color(xyz-D65 0.3 0.5 0.7)")
+        );
+
+        // alpha is supported
+        assert_eq!(
+            Some(Color::from_xyz(0.3, 0.5, 0.7, 0.9)),
+            parse_color("color(xyz-d65 0.3 0.5 0.7 / 0.9)")
+        );
+
+        // not enough parameters
+        assert_eq!(None, parse_color("color(xyz-d65 0.3 0.5)"));
+        // too many parameters
+        assert_eq!(None, parse_color("color(xyz-d65 0.3 0.5 0.7 1.0)"));
+        // comma separators not allowed
+        assert_eq!(None, parse_color("color(xyz-d65 0.3, 0.5, 0.7)"));
+    }
+
+    #[test]
+    fn parse_xyz50_color_space_syntax() {
+        // The D50-adapted `xyz-d50` color space is not currently supported.
+        assert_eq!(None, parse_color("color(xyz-d50 0.3 0.5 0.7)"));
     }
 }

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -1,0 +1,106 @@
+use std::fmt;
+
+use crate::{
+    convert::{gam_srgb, lin_srgb},
+    matrix::mat3_dot,
+    types::{Mat3, Scalar},
+    Color, RGBA,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct XYZ {
+    pub x: Scalar,
+    pub y: Scalar,
+    pub z: Scalar,
+    pub alpha: Scalar,
+}
+
+impl From<&Color> for XYZ {
+    fn from(color: &Color) -> Self {
+        #[rustfmt::skip]
+        const M: Mat3 = [
+            0.4124, 0.3576, 0.1805,
+            0.2126, 0.7152, 0.0722,
+            0.0193, 0.1192, 0.9505,
+        ];
+
+        let rec = RGBA::from(color);
+        let r_g_b_ = lin_srgb([rec.r, rec.g, rec.b]);
+        let [x, y, z] = mat3_dot(M, r_g_b_);
+
+        XYZ::with_alpha(x, y, z, color.alpha)
+    }
+}
+
+impl From<&XYZ> for Color {
+    fn from(color: &XYZ) -> Self {
+        #[rustfmt::skip]
+        const M_: Mat3 = [
+              3.2406, -1.5372, -0.4986,
+             -0.9689,  1.8758,  0.0415,
+              0.0557, -0.2040,  1.0570,
+        ];
+
+        let r_g_b_ = mat3_dot(M_, [color.x, color.y, color.z]);
+        let [r, g, b] = gam_srgb(r_g_b_);
+        Self::from(&RGBA::<f64> {
+            r,
+            g,
+            b,
+            alpha: color.alpha,
+        })
+    }
+}
+
+impl fmt::Display for XYZ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "XYZ({x}, {y}, {z})", x = self.x, y = self.y, z = self.z,)
+    }
+}
+
+impl XYZ {
+    #[inline]
+    pub fn new(x: Scalar, y: Scalar, z: Scalar) -> Self {
+        Self::with_alpha(x, y, z, 1.0)
+    }
+
+    #[inline]
+    pub fn with_alpha(x: Scalar, y: Scalar, z: Scalar, alpha: Scalar) -> Self {
+        XYZ { x, y, z, alpha }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_almost_equal(c1: &Color, c2: &Color) {
+        let c1 = c1.to_rgba();
+        let c2 = c2.to_rgba();
+
+        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
+        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
+        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
+    }
+
+    #[test]
+    fn xyz_conversion() {
+        assert_eq!(Color::white(), Color::from_xyz(0.9505, 1.0, 1.0890, 1.0));
+        assert_eq!(Color::red(), Color::from_xyz(0.4123, 0.2126, 0.01933, 1.0));
+        assert_eq!(
+            Color::from_hsl(109.999, 0.08654, 0.407843),
+            Color::from_xyz(0.13123, 0.15372, 0.13174, 1.0)
+        );
+
+        let roundtrip = |h, s, l| {
+            let color1 = Color::from_hsl(h, s, l);
+            let xyz1 = color1.to_xyz();
+            let color2 = Color::from_xyz(xyz1.x, xyz1.y, xyz1.z, 1.0);
+            assert_almost_equal(&color1, &color2);
+        };
+
+        for hue in 0..360 {
+            roundtrip(Scalar::from(hue), 0.2, 0.8);
+        }
+    }
+}

--- a/src/xyz.rs
+++ b/src/xyz.rs
@@ -73,15 +73,7 @@ impl XYZ {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn assert_almost_equal(c1: &Color, c2: &Color) {
-        let c1 = c1.to_rgba();
-        let c2 = c2.to_rgba();
-
-        assert!((c1.r as i32 - c2.r as i32).abs() <= 1);
-        assert!((c1.g as i32 - c2.g as i32).abs() <= 1);
-        assert!((c1.b as i32 - c2.b as i32).abs() <= 1);
-    }
+    use crate::test_helper::assert_almost_equal;
 
     #[test]
     fn xyz_conversion() {


### PR DESCRIPTION
The `lib.rs` and `parser.rs` files in the `pastel` library crate were getting pretty monolithic. This made it more difficult to find all the functionality related to a specific color space, or to know where new functionality should be added. This PR reorganizes the library by adding private submodules that encapsulate the functionality for each supported color space. The public API types are then re-exported from the crate root in `lib.rs` to maintain the same API surface.